### PR TITLE
Add OCaml package manager (OPAM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Just run `topgrade`. It will run the following steps:
 * Update Rustup by running `rustup update`. This will also attempt to run `rustup self update` when Rustup is installed inside the home directory.
 * Run Cargo [install-update](https://github.com/nabijaczleweli/cargo-update)
 * Upgrade Emacs packages (You'll get a better output if you have [Paradox](https://github.com/Malabarba/paradox) installed)
+* Upgrade [OCaml packages](https://opam.ocaml.org/)
 * Upgrade Vim/Neovim packages. Works with the following plugin frameworks:
   * [NeoBundle](https://github.com/Shougo/neobundle.vim)
   * [Vundle](https://github.com/VundleVim/Vundle.vim)

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -95,6 +95,23 @@ pub fn run_rustup(base_dirs: &BaseDirs, terminal: &mut Terminal, dry_run: bool) 
 }
 
 #[must_use]
+pub fn run_opam_update(terminal: &mut Terminal, dry_run: bool) -> Option<(&'static str, bool)> {
+    if let Some(opam) = utils::which("opam") {
+        terminal.print_separator("OCaml Package Manager");
+
+        let success = || -> Result<(), Error> {
+            Executor::new(&opam, dry_run).arg("update").spawn()?.wait()?.check()?;
+            Executor::new(&opam, dry_run).arg("upgrade").spawn()?.wait()?.check()?;
+            Ok(())
+        }().is_ok();
+
+        return Some(("OPAM", success));
+    }
+
+    None
+}
+
+#[must_use]
 pub fn run_custom_command(name: &str, command: &str, terminal: &mut Terminal, dry_run: bool) -> Result<(), Error> {
     terminal.print_separator(name);
     Executor::new("sh", dry_run)

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,10 @@ fn run() -> Result<(), Error> {
         &mut terminal,
     ));
     report.push_result(execute(
+        |terminal| generic::run_opam_update(terminal, dry_run),
+        &mut terminal,
+    ));
+    report.push_result(execute(
         |terminal| vim::upgrade_vim(&base_dirs, terminal, dry_run),
         &mut terminal,
     ));


### PR DESCRIPTION
This adds support for the [OCaml package manager](https://opam.ocaml.org/) (OPAM).

The command line `opam update` first performs a self-update if necessary. Then it updates its package list.
Finally, `opam upgrade` upgrades all locally installed packages.
