### PR TITLE
Adding Scoop to list of Supported package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Just run `topgrade`. It will run the following steps:
 * *Unix*: Run `brew update && brew upgrade`. This should handle both Homebrew and Linuxbrew
 * *Windows*: Upgrade Powershell modules
 * *Windows*: Upgrade all [Chocolatey](https://chocolatey.org/) packages
+* *Windows*: Upgrade all [Scoop](https://scoop.sh) packages
 * Check if the following paths are tracked by Git. If so, pull them:
   * ~/.emacs.d (Should work whether you use [Spacemacs](http://spacemacs.org/) or a custom configuration)
   * ~/.zshrc


### PR DESCRIPTION
I just updated the README.md to reflect the new support for the scoop package manager 