### PR TITLE
Adding a new flag for cleaning up old resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Just run `topgrade`. It will run the following steps:
 ## Flags
 * `-t/--tmux` - Topgrade will launch itself in a new tmux session. This flag has no effect if
   Topgrade already runs inside tmux. This is useful when using topgrade on remote systems.
+* `-c/--cleanup` - Topgrade will instruct package managers to remove old or unused files
 * `-n/--dry-run` - Print what should be run.
 * `--no-system` - Skip the system upgrade phase.
 * `--no-git-repos` - Don't pull custom git repositories.

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,9 @@ pub struct Opt {
     #[structopt(short = "t", long = "tmux", help = "Run inside tmux")]
     pub run_in_tmux: bool,
 
+    #[structopt(short = "c", long = "cleanup", help = "Cleanup temporary or old files")]
+    pub cleanup: bool,
+
     #[structopt(long = "no-system", help = "Don't perform system upgrade")]
     pub no_system: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ fn run() -> Result<(), Error> {
 
     #[cfg(unix)]
     report.push_result(execute(
-        |terminal| unix::run_homebrew(terminal, opt.dry_run),
+        |terminal| unix::run_homebrew(terminal, opt.cleanup, opt.dry_run),
         &mut execution_context,
     )?);
     #[cfg(unix)]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -52,13 +52,16 @@ pub fn run_fisher(base_dirs: &BaseDirs, terminal: &mut Terminal, dry_run: bool) 
 }
 
 #[must_use]
-pub fn run_homebrew(terminal: &mut Terminal, dry_run: bool) -> Option<(&'static str, bool)> {
+pub fn run_homebrew(terminal: &mut Terminal, cleanup: bool, dry_run: bool) -> Option<(&'static str, bool)> {
     if let Some(brew) = which("brew") {
         terminal.print_separator("Brew");
 
         let inner = || -> Result<(), Error> {
             Executor::new(&brew, dry_run).arg("update").spawn()?.wait()?.check()?;
             Executor::new(&brew, dry_run).arg("upgrade").spawn()?.wait()?.check()?;
+            if cleanup {
+                Executor::new(&brew, dry_run).arg("cleanup").spawn()?.wait()?.check()?;
+            }
             Ok(())
         };
 


### PR DESCRIPTION
If you are using applications like brew they may keep a history of
packages downloaded. Especially the bigger your number of installed
packages for homebrew gets the bigger those directories get. This can
quickly add up to a couple of GBs.

In my current workflow of updating, I was always cleaning up homebrews / linuxbrews "unneeded" resources after running it.

This pull-request adds a new flag to topgrade that enables users to explicitly ask for removing those kind of files. The PR contains an implementation for "brew" but it can easily spread to other commands as well. 