### PR TITLE
Add `--no-vim` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Just run `topgrade`. It will run the following steps:
 * `--no-git-repos` - Don't pull custom git repositories.
 * `--no-emacs` - Don't upgrade Emacs packages or configuration files.
 * `--no-retry` - Don't ask to retry failed steps.
+* `--no-vim` - Don't upgrade Vim/NeoVim packages or configuration files.
 
 ## Customization
 You can place a configuration file at `~/.config/topgrade.toml` (on macOS `~/Library/Preferences/topgrade.toml`).. Here's an example:

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,10 @@ pub struct Opt {
     #[structopt(long = "no-emacs")]
     pub no_emacs: bool,
 
+    /// Don't upgrade Vim packages or configuration files
+    #[structopt(long = "no-vim")]
+    pub no_vim: bool,
+
     /// Print what would be done
     #[structopt(short = "n", long = "dry-run")]
     pub dry_run: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,8 +179,10 @@ fn run() -> Result<(), Error> {
         git_repos.insert(base_dirs.home_dir().join(".emacs.d"));
     }
 
-    git_repos.insert(base_dirs.home_dir().join(".vim"));
-    git_repos.insert(base_dirs.home_dir().join(".config/nvim"));
+    if !opt.no_vim {
+        git_repos.insert(base_dirs.home_dir().join(".vim"));
+        git_repos.insert(base_dirs.home_dir().join(".config/nvim"));
+    }
 
     #[cfg(unix)]
     {
@@ -227,8 +229,12 @@ fn run() -> Result<(), Error> {
     report.push_result(execute(|| generic::run_vcpkg_update(opt.dry_run), opt.no_retry)?);
     report.push_result(execute(|| generic::run_pipx_update(opt.dry_run), opt.no_retry)?);
     report.push_result(execute(|| generic::run_jetpack(opt.dry_run), opt.no_retry)?);
-    report.push_result(execute(|| vim::upgrade_vim(&base_dirs, opt.dry_run), opt.no_retry)?);
-    report.push_result(execute(|| vim::upgrade_neovim(&base_dirs, opt.dry_run), opt.no_retry)?);
+
+    if !opt.no_vim {
+        report.push_result(execute(|| vim::upgrade_vim(&base_dirs, opt.dry_run), opt.no_retry)?);
+        report.push_result(execute(|| vim::upgrade_neovim(&base_dirs, opt.dry_run), opt.no_retry)?);
+    }
+
     report.push_result(execute(
         || node::run_npm_upgrade(&base_dirs, opt.dry_run),
         opt.no_retry,


### PR DESCRIPTION
Just like we have the `--no-emacs` flag, it would be nice to have the `--no-vim` flag, to avoid the upgrade of the vim/neovim configuration files and packages.
