### PR TITLE
Implement cleanup for Debian based distros

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -242,7 +242,7 @@ fn upgrade_debian(sudo: &Option<PathBuf>, cleanup: bool, dry_run: bool) -> Resul
             .wait()?
             .check()?;
 
-        if cleanup {   
+        if cleanup {
             Executor::new(&sudo, dry_run)
                 .args(&["/usr/bin/apt", "clean"])
                 .spawn()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,9 +116,10 @@ fn run() -> Result<(), Error> {
         if !opt.no_system {
             match &distribution {
                 Ok(distribution) => {
-                    report.push_result(
-                        execute(|| distribution.upgrade(&sudo, opt.cleanup, opt.dry_run), opt.no_retry)?
-                    );
+                    report.push_result(execute(
+                        || distribution.upgrade(&sudo, opt.cleanup, opt.dry_run),
+                        opt.no_retry,
+                    )?);
                 }
                 Err(e) => {
                     println!("Error detecting current distribution: {}", e);


### PR DESCRIPTION
With the cleanup flag enabled, topgrade runs `apt clean` and `apt autoremove`.