### PR TITLE
Add `--no-ruby` flag

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -76,9 +76,9 @@ pub struct Opt {
     #[structopt(long = "no-vim")]
     pub no_vim: bool,
 
-    /// Don't upgrade ruby packages or configuration files
-    #[structopt(long = "no-ruby")]
-    pub no_ruby: bool,
+    /// Don't upgrade ruby gems
+    #[structopt(long = "no-gem")]
+    pub no_gem: bool,
 
     /// Print what would be done
     #[structopt(short = "n", long = "dry-run")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,10 @@ pub struct Opt {
     #[structopt(long = "no-vim")]
     pub no_vim: bool,
 
+    /// Don't upgrade ruby packages or configuration files
+    #[structopt(long = "no-ruby")]
+    pub no_ruby: bool,
+
     /// Print what would be done
     #[structopt(short = "n", long = "dry-run")]
     pub dry_run: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ fn run() -> Result<(), Error> {
     )))]
     report.push_result(execute(|| generic::run_apm(run_type), opt.no_retry)?);
 
-    if !opt.no_ruby {
+    if !opt.no_gem {
         report.push_result(execute(|| generic::run_gem(&base_dirs, run_type), opt.no_retry)?);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,10 @@ fn run() -> Result<(), Error> {
         target_os = "dragonfly"
     )))]
     report.push_result(execute(|| generic::run_apm(run_type), opt.no_retry)?);
-    report.push_result(execute(|| generic::run_gem(&base_dirs, run_type), opt.no_retry)?);
+
+    if !opt.no_ruby {
+        report.push_result(execute(|| generic::run_gem(&base_dirs, run_type), opt.no_retry)?);
+    }
 
     #[cfg(target_os = "linux")]
     {


### PR DESCRIPTION
Just like we have the other `--no-X` flags, it would be nice to have the `--no-ruby` flag, to avoid the upgrade of the ruby gems on systems that have gems installed and managed by the system package manager in a way that require additional configuration steps for us to be able to upgrade them.

For example, I have an Arch system that has ruby and rubygems installed and managed by pacman as part of dependencies for vagrant. Topgrade occasional fails when trying to upgrade some of the gems that are installed due to missing environment variables.