### PR TITLE
Normalize paths in Windows (fix #113)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
   - if [%APPVEYOR_REPO_TAG%]==[false] (
       cargo fmt --all -- --check &&
       cargo clippy --all-targets --all-features -- -D warnings &&
-      cargo clippy --all-targets -- -D warnings
+      cargo clippy --all-targets -- -D warnings &&
       cargo test
     )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ test_script:
       cargo fmt --all -- --check &&
       cargo clippy --all-targets --all-features -- -D warnings &&
       cargo clippy --all-targets -- -D warnings
+      cargo test
     )
 
 before_deploy:

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,6 +9,7 @@ main() {
     cross clippy --all-targets --all-features -- -D warnings
 
     if [ ! -z $DISABLE_TESTS ]; then
+        cross test
         return
     fi
 

--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::executor::{CommandExt, RunType};
 use crate::terminal::print_separator;
-use crate::utils::which;
+use crate::utils::{which, HumanizedPath};
 use log::{debug, error};
 use std::collections::HashSet;
 use std::io;
@@ -58,7 +58,7 @@ impl Git {
     pub fn pull<P: AsRef<Path>>(&self, path: P, run_type: RunType) -> Option<(String, bool)> {
         let path = path.as_ref();
 
-        print_separator(format!("Pulling {}", path.display()));
+        print_separator(format!("Pulling {}", HumanizedPath::from(path)));
 
         let git = self.git.as_ref().unwrap();
 
@@ -73,7 +73,7 @@ impl Git {
         }()
         .is_ok();
 
-        Some((format!("git: {}", path.display()), success))
+        Some((format!("git: {}", HumanizedPath::from(path)), success))
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,29 +89,30 @@ impl<'a> fmt::Display for HumanizedPath<'a> {
             let mut iterator = self.path.components().peekable();
 
             while let Some(component) = iterator.next() {
-                let final_component = iterator.peek().is_none();
+                let mut print_seperator = iterator.peek().is_some();
 
                 match &component {
-                    Component::Normal(c) if *c == "?" => (),
-                    Component::RootDir | Component::CurDir => (),
+                    Component::Normal(c) if *c == "?" => {
+                        print_seperator = false;
+                    }
+                    Component::RootDir | Component::CurDir => {
+                        print_seperator = false;
+                    }
                     Component::ParentDir => {
                         write!(f, "..")?;
-
-                        if !final_component {
-                            write!(f, "{}", std::path::MAIN_SEPARATOR)?;
-                        }
                     }
                     Component::Prefix(p) => {
-                        write!(f, "{}{}", p.as_os_str().to_string_lossy(), std::path::MAIN_SEPARATOR)?;
+                        write!(f, "{}", p.as_os_str().to_string_lossy())?;
+                        print_seperator = true;
                     }
                     Component::Normal(c) => {
                         write!(f, "{}", c.to_string_lossy())?;
-
-                        if !final_component {
-                            write!(f, "{}", std::path::MAIN_SEPARATOR)?;
-                        }
                     }
                 };
+
+                if print_seperator {
+                    write!(f, "{}", std::path::MAIN_SEPARATOR)?;
+                }
             }
         } else {
             write!(f, "{}", self.path.display())?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -71,8 +71,8 @@ pub fn which<T: AsRef<OsStr> + Debug>(binary_name: T) -> Option<PathBuf> {
 
 /// `std::fmt::Display` implementation for `std::path::Path`.
 ///
-/// This struct differs from `std::path::Display` in that in Windows it takes care of printing slashes
-/// instead of backslashes and don't print the `\\?` prefix in long paths.
+/// This struct differs from `std::path::Display` in that in Windows it takes care of printing backslashes
+/// instead of slashes and don't print the `\\?` prefix in long paths.
 pub struct HumanizedPath<'a> {
     path: &'a Path,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,32 +89,29 @@ impl<'a> fmt::Display for HumanizedPath<'a> {
             let mut iterator = self.path.components().peekable();
 
             while let Some(component) = iterator.next() {
-                let is_prefix = if let Component::Prefix(_) = &component {
-                    true
-                } else {
-                    false
-                };
+                let final_component = iterator.peek().is_none();
 
-                let printed = match &component {
-                    Component::Normal(c) if *c == "?" => false,
-                    Component::RootDir | Component::CurDir => false,
+                match &component {
+                    Component::Normal(c) if *c == "?" => (),
+                    Component::RootDir | Component::CurDir => (),
                     Component::ParentDir => {
                         write!(f, "..")?;
-                        true
+
+                        if !final_component {
+                            write!(f, "{}", std::path::MAIN_SEPARATOR)?;
+                        }
                     }
                     Component::Prefix(p) => {
-                        write!(f, "{}", p.as_os_str().to_string_lossy())?;
-                        true
+                        write!(f, "{}{}", p.as_os_str().to_string_lossy(), std::path::MAIN_SEPARATOR)?;
                     }
                     Component::Normal(c) => {
                         write!(f, "{}", c.to_string_lossy())?;
-                        true
+
+                        if !final_component {
+                            write!(f, "{}", std::path::MAIN_SEPARATOR)?;
+                        }
                     }
                 };
-
-                if printed && (iterator.peek().is_some() || is_prefix) {
-                    write!(f, "{}", std::path::MAIN_SEPARATOR)?;
-                }
             }
         } else {
             write!(f, "{}", self.path.display())?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,7 +89,7 @@ impl<'a> fmt::Display for HumanizedPath<'a> {
             let mut iterator = self.path.components().peekable();
 
             while let Some(component) = iterator.next() {
-                let is_prefix = if let Component::RootDir = &component {
+                let is_prefix = if let Component::Prefix(_) = &component {
                     true
                 } else {
                     false
@@ -121,5 +121,35 @@ impl<'a> fmt::Display for HumanizedPath<'a> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg(windows)]
+mod tests {
+    use super::*;
+
+    fn humanize<P: AsRef<Path>>(path: P) -> String {
+        format!("{}", HumanizedPath::from(path.as_ref()))
+    }
+
+    #[test]
+    fn test_just_drive() {
+        assert_eq!("C:\\", humanize("C:\\"));
+    }
+
+    #[test]
+    fn test_path() {
+        assert_eq!("C:\\hi", humanize("C:\\hi"));
+    }
+
+    #[test]
+    fn test_unc() {
+        assert_eq!("\\\\server\\share\\", humanize("\\\\server\\share"));
+    }
+
+    #[test]
+    fn test_long_path() {
+        assert_eq!("C:\\hi", humanize("//?/C:/hi"));
     }
 }


### PR DESCRIPTION
While `//?/C:/Users/Someone/config-files` is a valid path, it's not very human friendly.
Such paths are returned from `BaseDirs`. This patch formats them in the traditional way.