### PR TITLE
Add DragonFly BSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ package manager. Topgrade is tested on and knows the following platforms:
   * Gentoo
   * openSUSE
   * Void
+* DragonFly BSD
 * FreeBSD
 * macOS
 * Windows
@@ -52,6 +53,7 @@ Just run `topgrade`. It will run the following steps:
   * **openSUSE**: Run `zypper refresh && zypper dist-upgrade`
   * **Void**: Run `xbps-install -Su`
 * **Linux**: Run [etc-update](https://dev.gentoo.org/~zmedico/portage/doc/man/etc-update.1.html):
+* **DragonFly BSD**: Upgrade and audit packages
 * **FreeBSD**: Upgrade and audit packages
 * **Unix**: Run `brew update && brew upgrade`. This should handle both Homebrew and Linuxbrew
 * **Unix**: Run `nix upgrade-nix && nix --upgrade`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn run() -> Result<(), Error> {
 
     let mut report = Report::new();
 
-    #[cfg(any(target_os = "freebsd", target_os = "linux"))]
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "linux"))]
     let sudo = utils::which("sudo");
     let run_type = executor::RunType::new(config.dry_run());
 
@@ -186,6 +186,13 @@ fn run() -> Result<(), Error> {
         &mut report,
         "brew",
         || unix::run_homebrew(config.cleanup(), run_type),
+        config.no_retry(),
+    )?;
+    #[cfg(target_os = "dragonfly")]
+    execute(
+        &mut report,
+        "DragonFly BSD Packages",
+        || dragonfly::upgrade_packages(sudo.as_ref(), run_type),
         config.no_retry(),
     )?;
     #[cfg(target_os = "freebsd")]
@@ -496,6 +503,9 @@ fn run() -> Result<(), Error> {
 
         #[cfg(target_os = "freebsd")]
         freebsd::audit_packages(&sudo).ok();
+
+        #[cfg(target_os = "dragonfly")]
+        dragonfly::audit_packages(&sudo).ok();
     }
 
     if config.keep_at_end() {

--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -1,0 +1,29 @@
+use crate::error::{Error, ErrorKind};
+use crate::executor::RunType;
+use crate::terminal::print_separator;
+use crate::utils::require_option;
+use failure::ResultExt;
+use std::path::PathBuf;
+use std::process::Command;
+
+pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<(), Error> {
+    let sudo = require_option(sudo)?;
+    print_separator("DrgaonFly BSD Packages");
+    run_type
+        .execute(sudo)
+        .args(&["/usr/local/sbin/pkg", "upgrade"])
+        .check_run()
+}
+
+pub fn audit_packages(sudo: &Option<PathBuf>) -> Result<(), Error> {
+    if let Some(sudo) = sudo {
+        println!();
+        Command::new(sudo)
+            .args(&["/usr/local/sbin/pkg", "audit", "-Fr"])
+            .spawn()
+            .context(ErrorKind::ProcessExecution)?
+            .wait()
+            .context(ErrorKind::ProcessExecution)?;
+    }
+    Ok(())
+}

--- a/src/steps/os/mod.rs
+++ b/src/steps/os/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "dragonfly")]
+pub mod dragonfly;
 #[cfg(target_os = "freebsd")]
 pub mod freebsd;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
DragonFly BSD supports the same pkg upgrade and audit of FreeBSD, though the OS upgrade process is different.