### PR TITLE
 Support ID=gentoo in /etc/os-release 

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -394,4 +394,9 @@ mod tests {
     fn test_anarchy() {
         test_template(&include_str!("os_release/anarchy"), Distribution::Arch);
     }
+
+    #[test]
+    fn test_gentoo() {
+        test_template(&include_str!("os_release/gentoo"), Distribution::Gentoo);
+    }
 }

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -44,6 +44,7 @@ impl Distribution {
             (Some("fedora"), _) => Distribution::Fedora,
             (Some("void"), _) => Distribution::Void,
             (Some("solus"), _) => Distribution::Solus,
+            (Some("gentoo"), _) => Distribution::Gentoo,
             _ => Err(ErrorKind::UnknownLinuxDistribution)?,
         })
     }
@@ -53,10 +54,6 @@ impl Distribution {
             let os_release = Ini::load_from_file(OS_RELEASE_PATH).context(ErrorKind::UnknownLinuxDistribution)?;
 
             return Self::parse_os_release(&os_release);
-        }
-
-        if PathBuf::from("/etc/gentoo-release").exists() {
-            return Ok(Distribution::Gentoo);
         }
 
         Err(ErrorKind::UnknownLinuxDistribution)?

--- a/src/steps/os/os_release/gentoo
+++ b/src/steps/os/os_release/gentoo
@@ -1,0 +1,7 @@
+NAME=Gentoo
+ID=gentoo
+PRETTY_NAME="Gentoo/Linux"
+ANSI_COLOR="1;32"
+HOME_URL="https://www.gentoo.org/"
+SUPPORT_URL="https://www.gentoo.org/support/"
+BUG_REPORT_URL="https://bugs.gentoo.org/"


### PR DESCRIPTION
Some older installs have both `/etc/os-release` and `/etc/gentoo-release`. This commit fixes them not being identified.