### PR TITLE
Add an ssh_arguments configuration file field

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,7 @@ pub struct ConfigFile {
     git_repos: Option<Vec<String>>,
     disable: Option<Vec<Step>>,
     remote_topgrades: Option<Vec<String>>,
+    ssh_arguments: Option<String>,
 }
 
 impl ConfigFile {
@@ -268,6 +269,11 @@ impl Config {
     /// List of remote hosts to run Topgrade in
     pub fn remote_topgrades(&self) -> &Option<Vec<String>> {
         &self.config_file.remote_topgrades
+    }
+
+    /// Extra SSH arguments
+    pub fn ssh_arguments(&self) -> &Option<String> {
+        &self.config_file.ssh_arguments
     }
 
     /// Prompt for a key before exiting

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,14 @@ fn run() -> Result<(), Error> {
                 execute(
                     &mut report,
                     remote_topgrade,
-                    || generic::run_remote_topgrade(run_type, remote_topgrade, config.run_in_tmux()),
+                    || {
+                        generic::run_remote_topgrade(
+                            run_type,
+                            remote_topgrade,
+                            config.ssh_arguments(),
+                            config.run_in_tmux(),
+                        )
+                    },
                     config.no_retry(),
                 )?;
             }


### PR DESCRIPTION
Can be used to add SSH command-line arguments like `-o
ConnectTimeout=2`