### PR TITLE
Fix typo for keep option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -174,7 +174,7 @@ pub struct CommandLineArgs {
     #[structopt(short = "v", long = "verbose")]
     verbose: bool,
 
-    /// Prompt or a key before exiting
+    /// Prompt for a key before exiting
     #[structopt(short = "k", long = "keep")]
     keep_at_end: bool,
 }


### PR DESCRIPTION
The current documentation for this option does not make sense and the
documentation for the keep_at_end function differs. I made this change
assuming is a typo.