### PR TITLE
Add option to disable node package updates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ lazy_static! {
         m.insert("vim", Step::Vim);
         m.insert("emacs", Step::Emacs);
         m.insert("gem", Step::Gem);
+        m.insert("node", Step::Node);
         m.insert("sdkman", Step::Sdkman);
         m.insert("remotes", Step::Remotes);
         m.insert("rustup", Step::Rustup);
@@ -53,6 +54,8 @@ pub enum Step {
     Emacs,
     /// Don't upgrade ruby gems
     Gem,
+    /// Don't upgrade npm/composer/yarn packages
+    Node,
     /// Don't upgrade SDKMAN! and its packages
     Sdkman,
     /// Don't run remote Togprades

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,24 +351,26 @@ fn run() -> Result<(), Error> {
         )?;
     }
 
-    execute(
-        &mut report,
-        "NPM",
-        || node::run_npm_upgrade(&base_dirs, run_type),
-        config.no_retry(),
-    )?;
-    execute(
-        &mut report,
-        "composer",
-        || generic::run_composer_update(&base_dirs, run_type),
-        config.no_retry(),
-    )?;
-    execute(
-        &mut report,
-        "yarn",
-        || node::yarn_global_update(run_type),
-        config.no_retry(),
-    )?;
+    if config.should_run(Step::Node) {
+        execute(
+            &mut report,
+            "NPM",
+            || node::run_npm_upgrade(&base_dirs, run_type),
+            config.no_retry(),
+        )?;
+        execute(
+            &mut report,
+            "composer",
+            || generic::run_composer_update(&base_dirs, run_type),
+            config.no_retry(),
+        )?;
+        execute(
+            &mut report,
+            "yarn",
+            || node::yarn_global_update(run_type),
+            config.no_retry(),
+        )?;
+    }
 
     #[cfg(not(any(
         target_os = "freebsd",


### PR DESCRIPTION
This should add the option to disable node package updates in the `topgrade.toml` config.

I've put the different node-based package managers under the same name `"node"`, but some users might prefer more fine-grained control over each package manager. That should be considered in the future.

Alas, this is what I needed.