### PR TITLE
Add zr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Just run `topgrade`. It will run the following steps:
   * ~/.config/i3
   * Powershell Profile
   * Custom defined paths
+* **Unix**: Run [zr](https://github.com/jedahan/zr) update
 * **Unix**: Run [zplug](https://github.com/zplug/zplug) update
 * **Unix**: Run [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) update
 * **Unix**: Run [fisher](https://github.com/jorgebucaran/fisher)

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,12 @@ fn run() -> Result<(), Error> {
     {
         execute(
             &mut report,
+            "zr",
+            || unix::run_zr(&base_dirs, run_type),
+            config.no_retry(),
+        )?;
+        execute(
+            &mut report,
             "zplug",
             || unix::run_zplug(&base_dirs, run_type),
             config.no_retry(),

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -7,6 +7,22 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+pub fn run_zr(base_dirs: &BaseDirs, run_type: RunType) -> Result<(), Error> {
+    let zsh = require("zsh")?;
+
+    env::var("ZR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| base_dirs.home_dir().join(".zr"))
+        .require()?;
+
+    print_separator("zr");
+
+    let zshrc = base_dirs.home_dir().join(".zshrc");
+
+    let cmd = format!("source {} && zr update", zshrc.display());
+    run_type.execute(zsh).args(&["-c", cmd.as_str()]).check_run()
+}
+
 pub fn run_zplug(base_dirs: &BaseDirs, run_type: RunType) -> Result<(), Error> {
     let zsh = require("zsh")?;
 


### PR DESCRIPTION
[zr](https://github.com/jedahan/zr) is a simple zsh package manager, written in rust.

I tried to keep this as similar as possible to the other update mechanism, but do have a few questions for the future:

1. Should we use deeper integration by bringing making `zr` a library and bringing it in as a dependency in the future?
2. Should we really be sourcing the entirety of zshrc when doing shell stuff? Feels side-effecty, but if thats the best way to have the right paths for everything, *shrug*?
3. Should I just make the above two questions issues to discuss separately from this PR?