### PR TITLE
Use '--no-pager' flag for git-log

### DIFF
--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -129,6 +129,7 @@ impl Git {
                                 Command::new(&cloned_git)
                                     .current_dir(&repo)
                                     .args(&[
+                                        "--no-pager",
                                         "log",
                                         "--no-decorate",
                                         "--oneline",


### PR DESCRIPTION
When there are a log of changes in the git step, topgrade might be "stack" in pager (e.g. less) until the user will manually exit it.
Using '--no-pager' flag allow all the changes to be printed to screen regardless of the amount of commits or the user's git configuration.