### PR TITLE
Allow most command-line options to be configured in config file (closes #188)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -4,8 +4,17 @@
 #    "~/.config/something"
 #]
 
-# Same options as the command line flag
+# Disable specific steps - same options as the command line flag
 #disable = ["system", "emacs"]
+
+# Run specific steps - same options as the command line flag
+#only = ["system", "emacs"]
+
+# Do not ask to retry failed steps (default: false)
+#no_retry = true
+
+# Run inside tmux
+#run_in_tmux = true
 
 # List of remote machines with Topgrade installed on them
 #remote_topgrades = ["toothless", "pi", "parnas"]
@@ -28,3 +37,9 @@
 # Custom commands
 #[commands]
 #"Python Environment" = "~/dev/.env/bin/pip install -i https://pypi.python.org/simple -U --upgrade-strategy eager jupyter"
+
+# Output logs
+#verbose = true
+
+# Cleanup temporary or old files
+#cleanup = true


### PR DESCRIPTION
@r-darwish There are some parts I'm not 100% sure about the correct behavior (mostly allowed steps), let me know what you think, we can change some implementation details.

But it works :)

Notes: 
* We lose ConfigFile::read(base_dirs) logs with verbosity on, but we don't have verbosity from config before reading the config file.. I think behavior should be the same for -v and `verbose = true`. 

* It seems `yes` was already implemented but the behavior is weird, the name is `assume_yes` and the config takes precedent to the command line? :confused: 