### PR TITLE
Handle gracefully config path not existing (Fixes #238)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -38,8 +38,5 @@
 #[commands]
 #"Python Environment" = "~/dev/.env/bin/pip install -i https://pypi.python.org/simple -U --upgrade-strategy eager jupyter"
 
-# Output logs
-#verbose = true
-
 # Cleanup temporary or old files
 #cleanup = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ pub struct ConfigFile {
 
 impl ConfigFile {
     fn ensure(base_dirs: &BaseDirs) -> Result<PathBuf, Error> {
-        let config_path = base_dirs.config_dir().join("/plooopy/topgrade.toml");
+        let config_path = base_dirs.config_dir().join("topgrade.toml");
         if !config_path.exists() {
             write(&config_path, include_str!("../config.example.toml"))
                 .map_err(|e| {
@@ -118,26 +118,6 @@ impl ConfigFile {
             .and_then(|mut p| p.wait())
             .context(ErrorKind::Configuration)?;
         Ok(())
-    }
-
-    /// Creates a new, blank config file.
-    fn new() -> ConfigFile {
-        ConfigFile {
-            pre_commands: None,
-            commands: None,
-            git_repos: None,
-            disable: None,
-            remote_topgrades: None,
-            ssh_arguments: None,
-            git_arguments: None,
-            set_title: None,
-            assume_yes: None,
-            yay_arguments: None,
-            no_retry: None,
-            run_in_tmux: None,
-            cleanup: None,
-            only: None,
-        }
     }
 }
 
@@ -212,7 +192,7 @@ impl Config {
 
         builder.init();
 
-        let config_file = ConfigFile::read(base_dirs).unwrap_or_else(|_| ConfigFile::new());
+        let config_file = ConfigFile::read(base_dirs).unwrap_or_else(|_| ConfigFile::default());
 
         let allowed_steps = Self::allowed_steps(&opt, &config_file);
 


### PR DESCRIPTION
Note: removed verbosity from config file, as failing while reading the config file needs a logger output and env_logger can't be init twice or changed after init as far as I could tell.

@r-darwish WDYT?