### PR TITLE
Fix whitespace in emacs lisp code

### DIFF
--- a/src/steps/emacs.rs
+++ b/src/steps/emacs.rs
@@ -41,11 +41,18 @@ impl Emacs {
 
         print_separator("Emacs");
 
+        // Convert the whitespace in the emacs lisp code to NONBREAKING SPACE.
+        let escaped: String = EMACS_UPGRADE
+            .chars()
+            .map(|c| if c.is_whitespace() { '\u{00a0}' } else { c })
+            .collect();
+
         run_type
             .execute(&emacs)
             .args(&["--batch", "-l"])
             .arg(init_file)
-            .args(&["--eval", EMACS_UPGRADE])
+            .arg("--eval")
+            .arg(escaped)
             .check_run()
     }
 }


### PR DESCRIPTION
On emacs 26.2, when the `--eval` argument to emacs contains spaces, it results in this error: 

```
End of file during parsing
```

It is enough to reproduce this with:

```
emacs --batch --eval "(if 1 0 42)"
```

and likewise with escaping (not that it should matter):

```
emacs --batch --eval "(if\ 1\ 0\ 42)"
```

It does seem that replacing these with 0xA0 (non-breaking space) works, though, and it's the best workaround I could find, though hackish.

