### PR TITLE
Support updating asdf plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Just run `topgrade`. It will run the following steps:
 * **DragonFly BSD**: Upgrade and audit packages
 * **FreeBSD**: Upgrade and audit packages
 * **Unix**: Run `brew update && brew upgrade`. This should handle both Homebrew and Linuxbrew
+* **Unix**: Run [asdf](https://github.com/asdf-vm/asdf-plugins)'s `asdf plugin-update --all`
 * **Unix**: Run `nix upgrade-nix && nix --upgrade`.
 * **Unix**: Run [Pearl](https://github.com/pearl-core/pearl) `pearl update`.
 * **Windows**: Run Topgrade inside WSL.

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ pub enum Step {
     Firmware,
     Restarts,
     Tldr,
+    Asdf,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,13 @@ fn run() -> Result<()> {
         runner.execute("voom", || vim::run_voom(&base_dirs, run_type))?;
     }
 
+    #[cfg(unix)]
+    {
+        if config.should_run(Step::Asdf) {
+            runner.execute("asdf", || generic::run_asdf_update(run_type))?;
+        }
+    }
+
     if config.should_run(Step::Node) {
         runner.execute("NPM", || node::run_npm_upgrade(&base_dirs, run_type))?;
         runner.execute("yarn", || node::yarn_global_update(run_type))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -172,6 +172,15 @@ pub fn run_custom_command(name: &str, command: &str, ctx: &ExecutionContext) -> 
     ctx.run_type().execute(shell()).arg("-c").arg(command).check_run()
 }
 
+#[cfg(unix)]
+pub fn run_asdf_update(run_type: RunType) -> Result<()> {
+    let asdf = utils::require("asdf")?;
+
+    print_separator("Asdf");
+
+    run_type.execute(&asdf).args(&["plugin-update", "--all"]).check_run()
+}
+
 pub fn run_composer_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let composer = utils::require("composer")?;
     let composer_home = Command::new(&composer)


### PR DESCRIPTION
There can be a lot of them: https://github.com/asdf-vm/asdf-plugins

I was thinking about the updating for the underlying versions of things that are managed via asdf, but that has a lot more potential complexity there.