### PR TITLE
Fix tldr upgrade when using tealdeer

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -83,8 +83,7 @@ pub fn run_tldr(run_type: RunType) -> Result<()> {
     let tldr = require("tldr")?;
 
     print_separator("TLDR");
-    run_type.execute(&tldr).arg("--update").check_run()?;
-    run_type.execute(&tldr).arg("-v").check_run()
+    run_type.execute(&tldr).arg("--update").check_run()
 }
 
 pub fn run_pearl(run_type: RunType) -> Result<()> {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -83,7 +83,8 @@ pub fn run_tldr(run_type: RunType) -> Result<()> {
     let tldr = require("tldr")?;
 
     print_separator("TLDR");
-    run_type.execute(&tldr).args(&["--update", "-v"]).check_run()
+    run_type.execute(&tldr).arg("--update").check_run()?;
+    run_type.execute(&tldr).arg("-v").check_run()
 }
 
 pub fn run_pearl(run_type: RunType) -> Result<()> {


### PR DESCRIPTION
I'm using [tealdeer](https://github.com/dbrgn/tealdeer) as my tldr client and when using topgrade the ugprade didn't work because tealdeer only executed the -v command and not the --update one. This PR changes the step to also work with tealdeer.