### PR TITLE
Skip the NPM root check in macOS (fix #303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Just run `topgrade`. It will run the following steps:
 * **Linux**: Update snap packages
 * **Linux**: Run [fwupdmgr](https://github.com/hughsie/fwupd) to show firmware upgrade. (View
   only. No upgrades will actually be performed)
-* **Linux**: Run `rpi-update` to update Raspberry Pi Firmware
 * **Linux**: Run [pihole](https://pi-hole.net/) updater
 * Run custom defined commands
 * Final stage
   * **Linux**: Run [needrestart](https://github.com/liske/needrestart)
   * **Windows**: Run Windows Update (You'll have to install [PSWindowsUpdate](https://marckean.com/2016/06/01/use-powershell-to-install-windows-updates/))
-  * **macOS**: Upgrade App Store applications
+  * **macOS**: Upgrade App Store applications using [mas](https://github.com/mas-cli/mas)
+  * **macOS**: Upgrade the system
   * **FreeBSD**: Run `freebsd-upgrade`
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Just run `topgrade`. It will run the following steps:
   * [Voom](https://github.com/airblade/voom)
 * Node
   * Run `yarn global update` if yarn is installed.
-  * Run `npm update -g` if NPM is installed and `npm root -g` is a path inside your home directory.
+  * Run `npm update -g`. In Unix systems other then macOS the step will be
+    performed only if`npm root -g` is a path inside your home directory.
 * Run `composer global update` if Composer's home directory is inside the home directory of the
   user. Run `valet install` after.
 * Upgrade Atom packages

--- a/src/main.rs
+++ b/src/main.rs
@@ -585,9 +585,11 @@ fn run() -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         if config.should_run(Step::System) {
+            execute(&mut report, "App Store", || macos::run_mas(run_type), config.no_retry())?;
+
             execute(
                 &mut report,
-                "App Store",
+                "System upgrade",
                 || macos::upgrade_macos(run_type),
                 config.no_retry(),
             )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,12 +570,6 @@ fn run() -> Result<()> {
                 || linux::run_fwupdmgr(run_type),
                 config.no_retry(),
             )?;
-            execute(
-                &mut report,
-                "rpi-update",
-                || linux::run_rpi_update(sudo.as_ref(), run_type),
-                config.no_retry(),
-            )?;
         }
 
         if config.should_run(Step::Restarts) {

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use crate::error::SkipStep;
 use crate::executor::{CommandExt, RunType};
 use crate::terminal::print_separator;
@@ -17,6 +18,7 @@ impl NPM {
         Self { command }
     }
 
+    #[cfg(not(target_os = "macos"))]
     fn root(&self) -> Result<PathBuf> {
         Command::new(&self.command)
             .args(&["root", "-g"])
@@ -31,11 +33,15 @@ impl NPM {
     }
 }
 
-pub fn run_npm_upgrade(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
+pub fn run_npm_upgrade(_base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let npm = require("npm").map(NPM::new)?;
-    let npm_root = npm.root()?;
-    if !npm_root.is_descendant_of(base_dirs.home_dir()) {
-        return Err(SkipStep.into());
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let npm_root = npm.root()?;
+        if !npm_root.is_descendant_of(_base_dirs.home_dir()) {
+            return Err(SkipStep.into());
+        }
     }
 
     print_separator("Node Package Manager");

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -441,15 +441,6 @@ pub fn run_snap(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     run_type.execute(sudo).arg(snap).arg("refresh").check_run()
 }
 
-pub fn run_rpi_update(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo)?;
-    let rpi_update = require("rpi-update")?;
-
-    print_separator("rpi-update");
-
-    run_type.execute(sudo).arg(rpi_update).check_run()
-}
-
 pub fn run_pihole_update(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo)?;
     let pihole = require("pihole")?;

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -1,9 +1,17 @@
 use crate::executor::RunType;
 use crate::terminal::print_separator;
+use crate::utils::require;
 use anyhow::Result;
 
+pub fn run_mas(run_type: RunType) -> Result<()> {
+    let mas = require("mas")?;
+    print_separator("macOS App Store");
+
+    run_type.execute(mas).arg("upgrade").check_run()
+}
+
 pub fn upgrade_macos(run_type: RunType) -> Result<()> {
-    print_separator("App Store");
+    print_separator("macOS system update");
 
     run_type
         .execute("softwareupdate")


### PR DESCRIPTION
macOS users install NPM using brew to /usr/local. This directory is
writable by the user