### PR TITLE
Only run "valet install" if valet was updated

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub enum Step {
     Emacs,
     Gem,
     Node,
+    Composer,
     Sdkman,
     Remotes,
     Rustup,

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,14 +499,17 @@ fn run() -> Result<()> {
         )?;
         execute(
             &mut report,
-            "composer",
-            || generic::run_composer_update(&base_dirs, run_type),
-            config.no_retry(),
-        )?;
-        execute(
-            &mut report,
             "yarn",
             || node::yarn_global_update(run_type),
+            config.no_retry(),
+        )?;
+    }
+
+    if config.should_run(Step::Composer) {
+        execute(
+            &mut report,
+            "composer",
+            || generic::run_composer_update(&base_dirs, run_type),
             config.no_retry(),
         )?;
     }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -186,10 +186,13 @@ pub fn run_composer_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()
 
     print_separator("Composer");
 
-    run_type.execute(&composer).args(&["global", "update"]).check_run()?;
-
-    if let Some(valet) = utils::which("valet") {
-        run_type.execute(&valet).arg("install").check_run()?;
+    let output = Command::new(&composer)
+        .args(&["global", "update"])
+        .check_output()?;
+    if output.contains("valet") {
+        if let Some(valet) = utils::which("valet") {
+            run_type.execute(&valet).arg("install").check_run()?;
+        }
     }
 
     Ok(())

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -186,9 +186,7 @@ pub fn run_composer_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()
 
     print_separator("Composer");
 
-    let output = Command::new(&composer)
-        .args(&["global", "update"])
-        .check_output()?;
+    let output = Command::new(&composer).args(&["global", "update"]).check_output()?;
     if output.contains("valet") {
         if let Some(valet) = utils::which("valet") {
             run_type.execute(&valet).arg("install").check_run()?;


### PR DESCRIPTION
Hi, and thanks for this awesome tool.

Currently, the `valet install` command is run after `composer global update`, regardless of whether or not it is necessary. `valet install` is a very time consuming command to run, since it restarts several background services (dnsmasq, php-fpm and nginx) sequentially. It will also stop the upgrade process and prompt for a password unless the `valet` and `brew` users have been added to the sudoers file.

As far as I know, running `valet install` only makes sense if valet was updated during the composer update, so that's what this pull request tries to achieve.

I couldn't figure out how to obtain the command output from `Executor`, so in stead I'm running the `Command` directly - which means that the output isn't streamed to stdout like it should. Please let me know if there's a better way to achieve this. I'm very new at Rust, so there's still a lot I don't understand. 