### PR TITLE
Support update of zsh plugin with antibody

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Just run `topgrade`. It will run the following steps:
 * **Unix**: Run [zplug](https://github.com/zplug/zplug) update
 * **Unix**: Run [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) update
 * **Unix**: Run [antigen](https://github.com/zsh-users/antigen) update
+* **Unix**: Run [antibody](https://getantibody.github.io/) update
 * **Unix**: Run [fisher](https://github.com/jorgebucaran/fisher)
 * **Unix**: Upgrade tmux plugins with [TPM](https://github.com/tmux-plugins/tpm). *Note*: Do not use
   the `-b` flag in your configuration as suggested by the TPM readme.

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,7 @@ fn run() -> Result<()> {
     {
         if config.should_run(Step::Shell) {
             runner.execute("zr", || zsh::run_zr(&base_dirs, run_type))?;
+            runner.execute("antibody", || zsh::run_antibody(run_type))?;
             runner.execute("antigen", || zsh::run_antigen(&base_dirs, run_type))?;
             runner.execute("zplug", || zsh::run_zplug(&base_dirs, run_type))?;
             runner.execute("zplugin", || zsh::run_zplugin(&base_dirs, run_type))?;

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -26,6 +26,15 @@ pub fn zshrc(base_dirs: &BaseDirs) -> PathBuf {
         .unwrap_or_else(|_| base_dirs.home_dir().join(".zshrc"))
 }
 
+pub fn run_antibody(run_type: RunType) -> Result<()> {
+    require("zsh")?;
+    let antibody = require("antibody")?;
+
+    print_separator("antibody");
+
+    run_type.execute(antibody).arg("update").check_run()
+}
+
 pub fn run_antigen(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc(base_dirs).require()?;


### PR DESCRIPTION
This PR adds support for updating zsh plugins using [antibody](https://getantibody.github.io/).