### PR TITLE
Better zinit renaming handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ fn run() -> Result<()> {
             runner.execute("antibody", || zsh::run_antibody(run_type))?;
             runner.execute("antigen", || zsh::run_antigen(&base_dirs, run_type))?;
             runner.execute("zplug", || zsh::run_zplug(&base_dirs, run_type))?;
-            runner.execute("zplugin", || zsh::run_zplugin(&base_dirs, run_type))?;
+            runner.execute("zinit", || zsh::run_zinit(&base_dirs, run_type))?;
             runner.execute("oh-my-zsh", || zsh::run_oh_my_zsh(&base_dirs, run_type))?;
             runner.execute("fisher", || unix::run_fisher(&base_dirs, run_type))?;
             runner.execute("tmux", || tmux::run_tpm(&base_dirs, run_type))?;

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -73,12 +73,11 @@ pub fn run_zinit(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     print_separator("zinit");
 
     // Check whether this is a pre- or post- renaming installation
-    let zcommand;
-    if Path::new(&base_dirs.home_dir().join(".zinit")).exists() {
-        zcommand = "zinit";
+    let zcommand = if Path::new(&base_dirs.home_dir().join(".zinit")).exists() {
+        "zinit"
     } else {
-        zcommand = "zplugin";
-    }
+        "zplugin"
+    };
 
     let cmd = format!(
         "source {} && {} self-update && {} update --all",

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -75,10 +75,7 @@ pub fn run_zinit(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!(
-        "source {} && zinit self-update && zinit update --all",
-        zshrc.display()
-    );
+    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display());
     run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()
 }
 

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -68,14 +68,24 @@ pub fn run_zinit(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc(base_dirs).require()?;
 
-    env::var("ZPFX")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| base_dirs.home_dir().join(".zinit"))
-        .require()?;
+    env::var("ZPFX").map(PathBuf::from).unwrap().require()?;
 
     print_separator("zinit");
 
-    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display());
+    // Check whether this is a pre- or post- renaming installation
+    let zcommand;
+    if Path::new(&base_dirs.home_dir().join(".zinit")).exists() {
+        zcommand = "zinit";
+    } else {
+        zcommand = "zplugin";
+    }
+
+    let cmd = format!(
+        "source {} && {} self-update && {} update --all",
+        zshrc.display(),
+        zcommand,
+        zcommand
+    );
     run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()
 }
 

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -64,19 +64,19 @@ pub fn run_zplug(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()
 }
 
-pub fn run_zplugin(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
+pub fn run_zinit(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc(base_dirs).require()?;
 
-    env::var("ZPLGM[HOME_DIR]")
+    env::var("ZPFX")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| base_dirs.home_dir().join(".zplugin"))
+        .unwrap_or_else(|_| base_dirs.home_dir().join(".zinit"))
         .require()?;
 
-    print_separator("zplugin");
+    print_separator("zinit");
 
     let cmd = format!(
-        "source {} && zplugin self-update && zplugin update --all",
+        "source {} && zinit self-update && zinit update --all",
         zshrc.display()
     );
     run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()


### PR DESCRIPTION
Checking for `.zinit` and defaulting to `zplugin` if it's not present. See discussion in #320 

@strangelittlemonkey - see if it makes sense to you

Apologies in advance if the code is not idiomatic Rust.