### PR TITLE
[🐛 FIX] ignore EXIT_NOTHING_TO_DO for all fwupdmgr commands

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -403,12 +403,13 @@ pub fn run_fwupdmgr(run_type: RunType) -> Result<()> {
 
     print_separator("Firmware upgrades");
 
-    run_type.execute(&fwupdmgr).arg("refresh").check_run()?;
-    let exit_status = run_type.execute(&fwupdmgr).arg("get-updates").spawn()?.wait()?;
+    for argument in vec!["refresh", "get-updates"].into_iter() {
+        let exit_status = run_type.execute(&fwupdmgr).arg(argument).spawn()?.wait()?;
 
-    if let ExecutorExitStatus::Wet(e) = exit_status {
-        if !(e.success() || e.code().map(|c| c == 2).unwrap_or(false)) {
-            return Err(TopgradeError::ProcessFailed(e).into());
+        if let ExecutorExitStatus::Wet(e) = exit_status {
+            if !(e.success() || e.code().map(|c| c == 2).unwrap_or(false)) {
+                return Err(TopgradeError::ProcessFailed(e).into());
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #246.

The issue is detailed in [1] and following comments.

Based on the same reasoning as for "get-updates" discussed in [2], return code 2 (EXIT_NOTHING_TO_DO) would need to be ignore for "refresh" as well.

[1] https://github.com/r-darwish/topgrade/issues/246#issuecomment-586640775-permalink
[2] https://github.com/r-darwish/topgrade/issues/246#issuecomment-549117042-permalink