### PR TITLE
Comply with new xbps behaviour

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -238,12 +238,15 @@ fn upgrade_suse(sudo: &Option<PathBuf>, run_type: RunType) -> Result<()> {
 
 fn upgrade_void(sudo: &Option<PathBuf>, run_type: RunType) -> Result<()> {
     if let Some(sudo) = &sudo {
-        for _ in 0..2 {
-            run_type
-                .execute(&sudo)
-                .args(&["/usr/bin/xbps-install", "-Su"])
-                .check_run()?;
-        }
+        run_type
+            .execute(&sudo)
+            .args(&["/usr/bin/xbps-install", "-Su", "xbps"])
+            .check_run()?;
+
+        run_type
+            .execute(&sudo)
+            .args(&["/usr/bin/xbps-install", "-u"])
+            .check_run()?;
     } else {
         print_warning("No sudo detected. Skipping system upgrade");
     }


### PR DESCRIPTION
As per void-linux/xbps#194, `xbps-install` now forces one to first sync and upgrade `xbps` itself before doing a full system update.