### PR TITLE
Add notification display for linux targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ rust-ini = "0.14.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 notify-rust = "3.6.3"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+notify-rust = "3.6.3"
+
 [target.'cfg(unix)'.dependencies]
 nix = "0.17.0"
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,7 +1,7 @@
 use chrono::{Local, Timelike};
 use console::{style, Term};
 use lazy_static::lazy_static;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use notify_rust::Notification;
 use std::cmp::{max, min};
 use std::env;
@@ -65,14 +65,14 @@ impl Terminal {
                 .set_title(format!("{}Topgrade - {}", self.prefix, message.as_ref()));
         }
 
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
             if self.desktop_notification {
                 Notification::new()
                     .summary("Topgrade")
                     .body(message.as_ref())
                     .appname("topgrade")
-                    .timeout(5)
+                    .timeout(if cfg!(macos) { 5 } else { 5000 })
                     .show()
                     .ok();
             }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [ ] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

Adds notifications for linux using the same crate as macos, to help with #285 

The only difference is that the dbus notification takes timeouts in ms instead of s, so `.timeout(5)` instantly made the notification disappear again. I set it to 5000 to mirror 5 seconds, though at some point a configurable delay might be preferable?

I am not sure if the way I am including the dependency in Cargo.toml is the best; if there's a better way let me know and I will fix it!
