### PR TITLE
Fix Clippy 1.43 warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ use directories::BaseDirs;
 use log::{debug, LevelFilter};
 use pretty_env_logger::formatted_timed_builder;
 use serde::Deserialize;
-use shellexpand;
 use std::collections::BTreeMap;
 use std::fs::write;
 use std::path::PathBuf;
@@ -14,7 +13,6 @@ use std::process::Command;
 use std::{env, fs};
 use structopt::StructOpt;
 use strum::{EnumIter, EnumString, EnumVariantNames, IntoEnumIterator, VariantNames};
-use toml;
 
 type Commands = BTreeMap<String, String>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,6 @@ use self::steps::*;
 use self::terminal::*;
 use anyhow::{anyhow, Result};
 use log::debug;
-#[cfg(feature = "self-update")]
-use openssl_probe;
 use std::env;
 use std::io;
 use std::process::exit;

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -2,7 +2,6 @@ use super::terminal::*;
 #[cfg(windows)]
 use crate::error::Upgraded;
 use anyhow::{bail, Result};
-use self_update_crate;
 use self_update_crate::backends::github::{GitHubUpdateStatus, Update};
 use std::env;
 #[cfg(unix)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,6 @@ use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Output};
-use which_crate;
 
 pub trait Check {
     fn check(self) -> Result<()>;


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
