### PR TITLE
Fix clippy warning about useless closure

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -291,7 +291,7 @@ impl Config {
         let disabled_steps: Vec<Step> = if !opt.disable.is_empty() {
             opt.disable.clone()
         } else {
-            config_file.disable.as_ref().map_or_else(|| vec![], |v| v.clone())
+            config_file.disable.as_ref().map_or_else(Vec::new, |v| v.clone())
         };
 
         enabled_steps.retain(|e| !disabled_steps.contains(e));


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
