### PR TITLE
reorg linux os check, add ID_LIKE=fedora, add tests

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -43,18 +43,6 @@ impl Distribution {
         let id = section.get("ID");
         let id_like: Option<Vec<&str>> = section.get("ID_LIKE").map(|s| s.split_whitespace().collect());
 
-        if let Some(id_like) = id_like {
-            if id_like.contains(&"debian") || id_like.contains(&"ubuntu") {
-                return Ok(Distribution::Debian);
-            } else if id_like.contains(&"centos") {
-                return Ok(Distribution::CentOS);
-            } else if id_like.contains(&"suse") {
-                return Ok(Distribution::Suse);
-            } else if id_like.contains(&"arch") || id_like.contains(&"archlinux") {
-                return Ok(Distribution::Arch);
-            }
-        }
-
         Ok(match id {
             Some("centos") | Some("rhel") | Some("ol") => Distribution::CentOS,
             Some("clear-linux-os") => Distribution::ClearLinux,
@@ -66,7 +54,22 @@ impl Distribution {
             Some("gentoo") => Distribution::Gentoo,
             Some("exherbo") => Distribution::Exherbo,
             Some("nixos") => Distribution::NixOS,
-            _ => return Err(TopgradeError::UnknownLinuxDistribution.into()),
+            _ => {
+                if let Some(id_like) = id_like {
+                    if id_like.contains(&"debian") || id_like.contains(&"ubuntu") {
+                        return Ok(Distribution::Debian);
+                    } else if id_like.contains(&"centos") {
+                        return Ok(Distribution::CentOS);
+                    } else if id_like.contains(&"suse") {
+                        return Ok(Distribution::Suse);
+                    } else if id_like.contains(&"arch") || id_like.contains(&"archlinux") {
+                        return Ok(Distribution::Arch);
+                    } else if id_like.contains(&"fedora") {
+                        return Ok(Distribution::Fedora);
+                    }
+                }
+                return Err(TopgradeError::UnknownLinuxDistribution.into());
+            }
         })
     }
 
@@ -599,5 +602,15 @@ mod tests {
     #[test]
     fn test_nixos() {
         test_template(&include_str!("os_release/nixos"), Distribution::NixOS);
+    }
+
+    #[test]
+    fn test_fedoraremixonwsl() {
+        test_template(&include_str!("os_release/fedoraremixforwsl"), Distribution::Fedora);
+    }
+
+    #[test]
+    fn test_pengwinonwsl() {
+        test_template(&include_str!("os_release/pengwinonwsl"), Distribution::Debian);
     }
 }

--- a/src/steps/os/os_release/fedoraremixforwsl
+++ b/src/steps/os/os_release/fedoraremixforwsl
@@ -1,0 +1,14 @@
+NAME="Fedora Remix for WSL"
+VERSION="31"
+ID=fedoraremixforwsl
+ID_LIKE=fedora
+VERSION_ID=31
+PLATFORM_ID="platform:f31"
+PRETTY_NAME="Fedora Remix for WSL"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:fedoraproject:fedora:31"
+HOME_URL="https://github.com/WhitewaterFoundry/Fedora-Remix-for-WSL"
+SUPPORT_URL="https://github.com/WhitewaterFoundry/Fedora-Remix-for-WSL"
+BUG_REPORT_URL="https://github.com/WhitewaterFoundry/Fedora-Remix-for-WSL/issues"
+PRIVACY_POLICY_URL="https://github.com/WhitewaterFoundry/Fedora-Remix-for-WSL/blob/master/PRIVACY.md"
+FEDORA_REMIX_VERSION=31.5.0

--- a/src/steps/os/os_release/pengwinonwsl
+++ b/src/steps/os/os_release/pengwinonwsl
@@ -1,0 +1,11 @@
+PRETTY_NAME="Pengwin"
+NAME="Pengwin"
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+ID=debian
+ID_LIKE=debian
+HOME_URL="https://github.com/whitewaterfoundry/Pengwin"
+SUPPORT_URL="https://github.com/WhitewaterFoundry/Pengwin/issues"
+BUG_REPORT_URL="https://github.com/WhitewaterFoundry/Pengwin/issues"
+VERSION_CODENAME=bullseye
+PENGWIN_VERSION="20.6.3"


### PR DESCRIPTION
- check for specific ID first, then check for ID_LIKE
- added case for ID_LIKE=fedora
- added test for Fedora Remix on WSL
- added test for Pengwin (Debian-like on WSL)

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] I have tested the code myself

I hope this PR is better than my last. Regarding the reordering of the OS checks: it makes more sense to me to check for a specific ID first and then check the ID_LIKE cases. The tests run. I hope you don't mind. I'm still very new to Rust.