### PR TITLE
Add configuration flags for portage arguments

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -58,6 +58,8 @@
 #yay_arguments = "--nodevel"
 #trizen_arguments = "--devel"
 #enable_tlmgr = true
+emerge_sync_flags = "-q"
+emerge_update_flags = "-uDNa --with-bdeps=y world"
 
 #[windows]
 # Manually select Windows updates

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,17 @@ use std::{env, fs};
 use structopt::StructOpt;
 use strum::{EnumIter, EnumString, EnumVariantNames, IntoEnumIterator, VariantNames};
 
+macro_rules! str_value {
+    ($section:ident, $value:ident) => {
+        pub fn $value(&self) -> Option<&str> {
+            self.config_file
+                .$section
+                .as_ref()
+                .and_then(|section| section.$value.as_deref())
+        }
+    };
+}
+
 macro_rules! check_deprecated {
     ($config:expr, $old:ident, $section:ident, $new:ident) => {
         if $config.$old.is_some() {
@@ -110,6 +121,8 @@ pub struct Linux {
     trizen_arguments: Option<String>,
     dnf_arguments: Option<String>,
     enable_tlmgr: Option<bool>,
+    emerge_sync_flags: Option<String>,
+    emerge_update_flags: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -541,4 +554,7 @@ impl Config {
         !self.opt.disable_predefined_git_repos
             && get_deprecated!(&self.config_file, predefined_git_repos, git, pull_predefined).unwrap_or(true)
     }
+
+    str_value!(linux, emerge_sync_flags);
+    str_value!(linux, emerge_update_flags);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::{env, fs};
 use structopt::StructOpt;
 use strum::{EnumIter, EnumString, EnumVariantNames, IntoEnumIterator, VariantNames};
 
+#[allow(unused_macros)]
 macro_rules! str_value {
     ($section:ident, $value:ident) => {
         pub fn $value(&self) -> Option<&str> {
@@ -555,6 +556,9 @@ impl Config {
             && get_deprecated!(&self.config_file, predefined_git_repos, git, pull_predefined).unwrap_or(true)
     }
 
+    #[cfg(target_os = "linux")]
     str_value!(linux, emerge_sync_flags);
+
+    #[cfg(target_os = "linux")]
     str_value!(linux, emerge_update_flags);
 }


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
