### PR TITLE
Add support for the kubectl plugin package manager krew

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,7 @@ pub enum Step {
     Gem,
     Node,
     Composer,
+    Krew,
     Sdkman,
     Remotes,
     Rustup,

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,6 +332,10 @@ fn run() -> Result<()> {
         runner.execute("composer", || generic::run_composer_update(&ctx))?;
     }
 
+    if config.should_run(Step::Krew) {
+        runner.execute("krew", || generic::run_krew_upgrade(run_type))?;
+    }
+
     #[cfg(not(any(
         target_os = "freebsd",
         target_os = "openbsd",

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -79,6 +79,14 @@ pub fn run_rustup(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     run_type.execute(&rustup).arg("update").check_run()
 }
 
+pub fn run_krew_upgrade(run_type: RunType) -> Result<()> {
+    let krew = utils::require("kubectl-krew")?;
+
+    print_separator("Krew");
+
+    run_type.execute(&krew).args(&["upgrade"]).check_run()
+}
+
 pub fn run_jetpack(run_type: RunType) -> Result<()> {
     let jetpack = utils::require("jetpack")?;
 


### PR DESCRIPTION
Adds support for the kubectl plugin package manager krew

https://krew.sigs.k8s.io/

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
