### PR TITLE
Add support for -y flag in Chocolatey

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn run() -> Result<()> {
     #[cfg(windows)]
     {
         if config.should_run(Step::Chocolatey) {
-            runner.execute("Chocolatey", || windows::run_chocolatey(run_type))?;
+            runner.execute("Chocolatey", || windows::run_chocolatey(&ctx))?;
         }
 
         if config.should_run(Step::Scoop) {

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -7,11 +7,21 @@ use crate::utils::require;
 use anyhow::Result;
 use std::process::Command;
 
-pub fn run_chocolatey(run_type: RunType) -> Result<()> {
+pub fn run_chocolatey(ctx: &ExecutionContext) -> Result<()> {
     let choco = require("choco")?;
+    let yes = ctx.config().yes();
 
     print_separator("Chocolatey");
-    run_type.execute(&choco).args(&["upgrade", "all"]).check_run()
+
+    let mut command = ctx.run_type().execute(&choco);
+
+    command.args(&["upgrade", "all"]);
+
+    if yes {
+        command.arg("--yes");
+    }
+
+    command.check_run()
 }
 
 pub fn run_scoop(cleanup: bool, run_type: RunType) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
