### PR TITLE
option to use choco with gsudo on windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,7 @@ pub struct Vagrant {
 pub struct Windows {
     accept_all_updates: Option<bool>,
     self_rename: Option<bool>,
+    use_gsudo_with_choco: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -516,6 +517,16 @@ impl Config {
             .windows
             .as_ref()
             .and_then(|w| w.self_rename)
+            .unwrap_or(false)
+    }
+
+    /// Whether to use gsudo command with choco if available
+    #[allow(dead_code)]
+    pub fn use_gsudo_with_choco(&self) -> bool {
+        self.config_file
+            .windows
+            .as_ref()
+            .and_then(|w| w.use_gsudo_with_choco)
             .unwrap_or(false)
     }
 


### PR DESCRIPTION
- gsudo runs a command with elevated privileges
- https://github.com/gerardog/gsudo

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles
- [X] The code passes rustfmt
- [X] The code passes clippy
- [X] The code passes tests
- [X] *Optional:* I have tested the code myself
    - [X] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
