### PR TITLE
Remove superfluous space in config.example.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -40,7 +40,7 @@
 #]
 
 # Don't pull the predefined git repos
-# predefined_repos = false
+#predefined_repos = false
 
 # Arguments to pass Git when pulling Repositories
 #arguments = "--rebase --autostash"


### PR DESCRIPTION
Small fix. Removes a space between the comment character and the
predefined_repos option to create consistency with other options.

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
