### PR TITLE
Add remote_topgrade_path configuration option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -22,6 +22,9 @@
 # Arguments to pass SSH when upgrading remote systems
 #ssh_arguments = "-o ConnectTimeout=2"
 
+# Path to Topgrade executable on remote machines
+#remote_topgrade_path = [".cargo/bin/topgrade"]
+
 # Arguments to pass tmux when pulling Repositories
 #tmux_arguments = "-S /var/tmux.sock"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,6 +166,7 @@ pub struct ConfigFile {
     disable: Option<Vec<Step>>,
     ignore_failures: Option<Vec<Step>>,
     remote_topgrades: Option<Vec<String>>,
+    remote_topgrade_path: Option<String>,
     ssh_arguments: Option<String>,
     git_arguments: Option<String>,
     tmux_arguments: Option<String>,
@@ -464,6 +465,11 @@ impl Config {
     /// List of remote hosts to run Topgrade in
     pub fn remote_topgrades(&self) -> &Option<Vec<String>> {
         &self.config_file.remote_topgrades
+    }
+
+    /// Path to Topgrade executable used for all remote hosts
+    pub fn remote_topgrade_path(&self) -> &str {
+        self.config_file.remote_topgrade_path.as_deref().unwrap_or("topgrade")
     }
 
     /// Extra SSH arguments

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -253,10 +253,12 @@ pub fn run_composer_update(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_remote_topgrade(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
     let ssh = utils::require("ssh")?;
 
+    let topgrade = ctx.config().remote_topgrade_path();
+
     if ctx.config().run_in_tmux() && !ctx.run_type().dry() {
         #[cfg(unix)]
         {
-            crate::tmux::run_remote_topgrade(hostname, &ssh, ctx.config().tmux_arguments())?;
+            crate::tmux::run_remote_topgrade(hostname, &ssh, topgrade, ctx.config().tmux_arguments())?;
             Err(SkipStep.into())
         }
 
@@ -270,7 +272,7 @@ pub fn run_remote_topgrade(ctx: &ExecutionContext, hostname: &str) -> Result<()>
         }
 
         let env = format!("TOPGRADE_PREFIX={}", hostname);
-        args.extend(&["env", &env, "topgrade"]);
+        args.extend(&["env", &env, topgrade]);
 
         if ctx.config().yes() {
             args.push("-y");

--- a/src/steps/tmux.rs
+++ b/src/steps/tmux.rs
@@ -104,11 +104,12 @@ pub fn run_in_tmux(args: &Option<String>) -> ! {
     }
 }
 
-pub fn run_remote_topgrade(hostname: &str, ssh: &Path, tmux_args: &Option<String>) -> Result<()> {
+pub fn run_remote_topgrade(hostname: &str, ssh: &Path, topgrade: &str, tmux_args: &Option<String>) -> Result<()> {
     let command = format!(
-        "{ssh} -t {hostname} env TOPGRADE_PREFIX={hostname} TOPGRADE_KEEP_END=1 topgrade",
+        "{ssh} -t {hostname} env TOPGRADE_PREFIX={hostname} TOPGRADE_KEEP_END=1 {topgrade}",
         ssh = ssh.display(),
-        hostname = hostname
+        hostname = hostname,
+        topgrade = topgrade
     );
     Tmux::new(tmux_args)
         .build()


### PR DESCRIPTION
This (slightly hacky) option provides a global method of specifying a Topgrade executable outside of the standard $PATH (see #380). For instance, to use Topgrade executables from ~/.cargo/bin, one may specify `remote_topgrade_path = ".cargo/bin/topgrade"`. The remote upgrade command will then be something along the lines of `ssh -t <host> env TOPGRADE_PREFIX=<host> .cargo/bin/topgrade`, which is then resolved relative to the user's home directory.

This implementation opts to make this a global setting rather than undertake per-remote configuration, which is likely to require significantly more effort. However, pursuing per-remote setup is likely
a worthy future goal. This implementation also supports only UTF-8 strings, i.e. std::string::String, which is internally consistent but necessarily misses some valid setups.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.