### PR TITLE
Modify powershell step to fix compilation on macOS

### DIFF
--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -1,4 +1,3 @@
-#[cfg(windows)]
 use crate::execution_context::ExecutionContext;
 use crate::executor::CommandExt;
 use crate::terminal::{is_dumb, print_separator};


### PR DESCRIPTION
I noticed macOS compilation failing on powershell after commit https://github.com/r-darwish/topgrade/commit/abc6a8065b5ff92d65c4eb2c21e0b95b937cf393

The change there to use `ExecutionContext` would fail because it was conditionally compiled in only on windows, but the update function would be used on all targets.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
