### PR TITLE
Don't require sudo for ostree (fix #479)

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -229,6 +229,7 @@ fn upgrade_arch_linux(ctx: &ExecutionContext) -> Result<()> {
 fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
     if let Some(ostree) = Path::new("/usr/bin/rpm-ostree").if_exists() {
         let mut command = ctx.run_type().execute(ostree);
+        command.arg("upgrade");
         if ctx.config().yes() {
             command.arg("-y");
         }

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -227,14 +227,23 @@ fn upgrade_arch_linux(ctx: &ExecutionContext) -> Result<()> {
 }
 
 fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
+    if let Some(ostree) = Path::new("/usr/bin/rpm-ostree").if_exists() {
+        let mut command = ctx.run_type().execute(ostree);
+        if ctx.config().yes() {
+            command.arg("-y");
+        }
+
+        return command.check_run();
+    }
+
     if let Some(sudo) = &ctx.sudo() {
         let mut command = ctx.run_type().execute(&sudo);
         command
-            .arg(Path::new("/usr/bin/dnf").if_exists().unwrap_or_else(|| {
-                Path::new("/usr/bin/yum")
+            .arg(
+                Path::new("/usr/bin/dnf")
                     .if_exists()
-                    .unwrap_or_else(|| Path::new("/usr/bin/rpm-ostree"))
-            }))
+                    .unwrap_or_else(|| Path::new("/usr/bin/yum")),
+            )
             .arg("upgrade");
 
         if let Some(args) = ctx.config().dnf_arguments() {


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
