### PR TITLE
Make sure VIMRC doesn't contain \r (fix #476)

### DIFF
--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -35,7 +35,7 @@ fn nvimrc(base_dirs: &BaseDirs) -> Option<PathBuf> {
 
 fn upgrade(vim: &PathBuf, vimrc: &PathBuf, ctx: &ExecutionContext) -> Result<()> {
     let mut tempfile = tempfile::NamedTempFile::new()?;
-    tempfile.write_all(UPGRADE_VIM.as_bytes())?;
+    tempfile.write_all(UPGRADE_VIM.replace('\r', "").as_bytes())?;
     debug!("Wrote vim script to {:?}", tempfile.path());
 
     let output = ctx

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,8 +45,10 @@ where
 {
     fn if_exists(self) -> Option<Self> {
         if self.as_ref().exists() {
+            debug!("Path {:?} exists", self.as_ref());
             Some(self)
         } else {
+            debug!("Path {:?} doesn't exist", self.as_ref());
             None
         }
     }


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
