### PR TITLE
Fix remote_topgrade_path example value

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -23,7 +23,7 @@
 #ssh_arguments = "-o ConnectTimeout=2"
 
 # Path to Topgrade executable on remote machines
-#remote_topgrade_path = [".cargo/bin/topgrade"]
+#remote_topgrade_path = ".cargo/bin/topgrade"
 
 # Arguments to pass tmux when pulling Repositories
 #tmux_arguments = "-S /var/tmux.sock"


### PR DESCRIPTION
The `remote_topgrade_path` expects a string, not an array.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
