### PR TITLE
Allow remotes to be launched in new Windows terminal windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -132,7 +132,7 @@ pub struct Vagrant {
 pub struct Windows {
     accept_all_updates: Option<bool>,
     self_rename: Option<bool>,
-    use_gsudo_with_choco: Option<bool>,
+    open_remotes_in_new_terminal: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -396,15 +396,6 @@ impl Config {
         check_deprecated!(config_file, yay_arguments, linux, yay_arguments);
         check_deprecated!(config_file, accept_all_windows_updates, windows, accept_all_updates);
 
-        if config_file
-            .windows
-            .as_ref()
-            .map(|w| w.use_gsudo_with_choco.is_some())
-            .unwrap_or(false)
-        {
-            println!("use_gsudo_with_choco is deprecated and will be removed in the future. Topgrade will not automatically detect and use gsudo");
-        }
-
         let allowed_steps = Self::allowed_steps(&opt, &config_file);
 
         Ok(Self {
@@ -655,6 +646,14 @@ impl Config {
 
     pub fn show_skipped(&self) -> bool {
         self.opt.show_skipped
+    }
+
+    pub fn open_remotes_in_new_terminal(&self) -> bool {
+        self.config_file
+            .windows
+            .as_ref()
+            .and_then(|windows| windows.open_remotes_in_new_terminal)
+            .unwrap_or(false)
     }
 
     #[cfg(target_os = "linux")]

--- a/src/steps/remote/ssh.rs
+++ b/src/steps/remote/ssh.rs
@@ -1,29 +1,42 @@
-#[cfg(unix)]
-use crate::error::SkipStep;
-use crate::{execution_context::ExecutionContext, terminal::print_separator, utils};
+use crate::{error::SkipStep, execution_context::ExecutionContext, terminal::print_separator, utils};
 use anyhow::Result;
+
+fn prepare_async_ssh_command(args: &mut Vec<&str>) {
+    args.insert(0, "ssh");
+    args.push("--keep");
+}
 
 pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
     let ssh = utils::require("ssh")?;
 
     let topgrade = ctx.config().remote_topgrade_path();
+    let mut args = vec!["-t", hostname];
+
+    if let Some(ssh_arguments) = ctx.config().ssh_arguments() {
+        args.extend(ssh_arguments.split_whitespace());
+    }
+
+    let env = format!("TOPGRADE_PREFIX={}", hostname);
+    args.extend(&["env", &env, topgrade]);
+
+    if ctx.config().yes() {
+        args.push("-y");
+    }
 
     if ctx.config().run_in_tmux() && !ctx.run_type().dry() {
         #[cfg(unix)]
         {
-            let command = format!(
-                "{ssh} -t {hostname} env TOPGRADE_PREFIX={hostname} TOPGRADE_KEEP_END=1 {topgrade}",
-                ssh = ssh.display(),
-                hostname = hostname,
-                topgrade = topgrade
-            );
-
-            crate::tmux::run_command(ctx, &command)?;
+            prepare_async_ssh_command(&mut args);
+            crate::tmux::run_command(ctx, &args.join(" "))?;
             Err(SkipStep(String::from("Remote Topgrade launched in Tmux")).into())
         }
 
         #[cfg(not(unix))]
         unreachable!("Tmux execution is only implemented in Unix");
+    } else if ctx.config().open_remotes_in_new_terminal() && !ctx.run_type().dry() && cfg!(windows) {
+        prepare_async_ssh_command(&mut args);
+        ctx.run_type().execute("wt").args(&args).spawn()?;
+        Err(SkipStep(String::from("Remote Topgrade launched in an external terminal")).into())
     } else {
         let mut args = vec!["-t", hostname];
 


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
