### PR TITLE
Surpass Paradox prompt in Emacs

### DIFF
--- a/src/steps/emacs.el
+++ b/src/steps/emacs.el
@@ -1,5 +1,7 @@
 (if (fboundp 'paradox-upgrade-packages)
     (progn
+      (unless (boundp 'paradox-github-token)
+        (setq paradox-github-token t))
       (paradox-upgrade-packages)
       (princ
        (if (get-buffer "*Paradox Report*")


### PR DESCRIPTION
In goal to close #509 

The only goal of this line is to eliminate  this message from Emacs step.

```
Would you like to set up GitHub integration?
This will allow you to star/unstar packages from the Package Menu. (y or n) 
```
We this the Emacs steps have no interaction needed

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
