### PR TITLE
Fix zr update

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -14,14 +14,11 @@ use walkdir::WalkDir;
 pub fn run_zr(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let zsh = require("zsh")?;
 
-    env::var("ZR_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| base_dirs.home_dir().join(".zr"))
-        .require()?;
+    require("zr")?;
 
     print_separator("zr");
 
-    let cmd = format!("source {} && zr update", zshrc(base_dirs).display());
+    let cmd = format!("source {} && zr --update", zshrc(base_dirs).display());
     run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()
 }
 


### PR DESCRIPTION
ZR_HOME is removed from zr docs. And update command changed to 'zr --update'

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
