### PR TITLE
Fix some minor Vim issues

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -1,5 +1,5 @@
 if exists(":NeoBundleUpdate")
-    echo NeoBundle
+    echo "NeoBundle"
     NeoBundleUpdate
 endif
 

--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -11,7 +11,6 @@ endif
 if exists(":PlugUpgrade")
     echo "Plug"
     PlugUpgrade
-    PlugClean
     PlugUpdate
 endif
 

--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -27,7 +27,9 @@ pub fn vimrc(base_dirs: &BaseDirs) -> Result<PathBuf> {
 
 fn nvimrc(base_dirs: &BaseDirs) -> Result<PathBuf> {
     #[cfg(unix)]
-    let base_dir = base_dirs.config_dir();
+    let base_dir =
+        // Bypass directories crate as nvim doesn't use the macOS-specific directories.
+        std::env::var_os("XDG_CONFIG_HOME").map_or_else(|| base_dirs.home_dir().join(".config"), PathBuf::from);
 
     #[cfg(windows)]
     let base_dir = base_dirs.cache_dir();

--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -27,10 +27,12 @@ pub fn vimrc(base_dirs: &BaseDirs) -> Result<PathBuf> {
 
 fn nvimrc(base_dirs: &BaseDirs) -> Result<PathBuf> {
     #[cfg(unix)]
-    return base_dirs.home_dir().join(".config/nvim/init.vim").require();
+    let base_dir = base_dirs.config_dir();
 
     #[cfg(windows)]
-    return base_dirs.cache_dir().join("nvim/init.vim").require();
+    let base_dir = base_dirs.cache_dir();
+
+    base_dir.join("nvim/init.vim").require()
 }
 
 fn upgrade(vim: &PathBuf, vimrc: &PathBuf, ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

First off, topgrade previously didn't honor `XDG_CONFIG_HOME` and instead defaulted to a hard-coded `$HOME/.config`.
In the process, I also noticed an error for an undefined variable under NeoBundle due to missing quotes, as well as the `PlugClean` step for vim-plug not doing anything due to prompting for user input.

I'm open for discussion wrt the `PlugClean` thing, although I would personally prefer if topgrade would not unconditionally delete inactive plugins, as I personally sometimes turn some off for testing.