### PR TITLE
Fix Jetpack typo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Myrepos, "myrepos", || {
         generic::run_myrepos_update(&base_dirs, run_type)
     })?;
-    runner.execute(Step::Jetpack, "jetpak", || generic::run_jetpack(run_type))?;
+    runner.execute(Step::Jetpack, "jetpack", || generic::run_jetpack(run_type))?;
     runner.execute(Step::Vim, "vim", || vim::upgrade_vim(&base_dirs, &ctx))?;
     runner.execute(Step::Vim, "Neovim", || vim::upgrade_neovim(&base_dirs, &ctx))?;
     runner.execute(Step::Vim, "voom", || vim::run_voom(&base_dirs, run_type))?;


### PR DESCRIPTION
Fix summary jetpack typo.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
