### PR TITLE
Add deno upgrade step (fixes #526)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Vim, "voom", || vim::run_voom(&base_dirs, run_type))?;
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&base_dirs, run_type))?;
     runner.execute(Step::Node, "yarn", || node::yarn_global_update(run_type))?;
-    runner.execute(Step::Deno, "deno", || node::deno_update(&ctx))?;
+    runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;
     runner.execute(Step::Composer, "composer", || generic::run_composer_update(&ctx))?;
     runner.execute(Step::Krew, "krew", || generic::run_krew_upgrade(run_type))?;
     runner.execute(Step::Gem, "gem", || generic::run_gem(&base_dirs, run_type))?;

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -66,9 +66,9 @@ pub fn yarn_global_update(run_type: RunType) -> Result<()> {
     run_type.execute(&yarn).args(&["global", "upgrade", "-s"]).check_run()
 }
 
-pub fn deno_update(ctx: &ExecutionContext) -> Result<()> {
+pub fn deno_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let deno = require("deno")?;
 
     print_separator("Deno");
-    ctx.run_type().execute(&deno).arg("update").check_run()
+    ctx.run_type().execute(&deno).arg("upgrade").check_run()
 }


### PR DESCRIPTION
# Add deno upgrade step

Hi @r-darwish.  I changed the `deno` invocation to use the correct parameter.  Still working on testing this, but I should have it done very soon.  This now works on linux, so I expect it will work on the other OS's.

Resolves #526.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] Tested in linux
- [ ] Tested in windows
- [ ] Tested in mac
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
