### PR TITLE
--only will execute disabled steps (fix #533)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -458,7 +458,7 @@ impl Config {
             config_file.disable.as_ref().map_or_else(Vec::new, |v| v.clone())
         };
 
-        enabled_steps.retain(|e| !disabled_steps.contains(e));
+        enabled_steps.retain(|e| !disabled_steps.contains(e) || opt.only.contains(e));
         enabled_steps
     }
 


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
