### PR TITLE
Add option to use an alternative program to yay

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -63,6 +63,8 @@
 #greedy_cask = true
 
 #[linux]
+# The name yay equivalent program, for example paru
+#yay_binary_name = "yay"
 # Arguments to pass yay when updating packages
 #yay_arguments = "--nodevel"
 #trizen_arguments = "--devel"

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,7 @@ pub struct Brew {
 #[derive(Deserialize, Default, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Linux {
+    yay_binary_name: Option<String>,
     yay_arguments: Option<String>,
     trizen_arguments: Option<String>,
     dnf_arguments: Option<String>,
@@ -580,6 +581,14 @@ impl Config {
             .as_ref()
             .and_then(|s| s.trizen_arguments.as_deref())
             .unwrap_or("")
+    }
+    #[allow(dead_code)]
+    pub fn yay_binary_name(&self) -> &str {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|linux| linux.yay_binary_name.as_deref())
+            .unwrap_or("yay")
     }
 
     /// Extra yay arguments

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -148,6 +148,7 @@ fn upgrade_arch_linux(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.sudo();
     let run_type = ctx.run_type();
     let cleanup = ctx.config().cleanup();
+    let yay_binary_name = ctx.config().yay_binary_name();
 
     let path = {
         let mut path = OsString::from("/usr/bin:");
@@ -156,7 +157,7 @@ fn upgrade_arch_linux(ctx: &ExecutionContext) -> Result<()> {
     };
     debug!("Running Arch update with path: {:?}", path);
 
-    if let Some(yay) = which("yay") {
+    if let Some(yay) = which(&yay_binary_name) {
         run_type
             .execute(&yay)
             .arg("-Pw")


### PR DESCRIPTION
This PR would allow users to use something like [paru](https://github.com/morganamilo/paru) instead of yay, since they are mostly compatible with the arguments they use

would fix #548   


## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

