### PR TITLE
fisher self-update deprecated -> use fisher update

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -24,7 +24,7 @@ pub fn run_fisher(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     print_separator("Fisher");
     run_type
         .execute(&fish)
-        .args(&["-c", "fisher self-update"])
+        .args(&["-c", "fisher update"])
         .check_run()?;
 
     run_type.execute(&fish).args(&["-c", "fisher"]).check_run()

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -22,9 +22,8 @@ pub fn run_fisher(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
         .require()?;
 
     print_separator("Fisher");
-    run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()?;
 
-    run_type.execute(&fish).args(&["-c", "fisher"]).check_run()
+    run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()
 }
 
 pub fn run_oh_my_fish(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -22,10 +22,7 @@ pub fn run_fisher(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
         .require()?;
 
     print_separator("Fisher");
-    run_type
-        .execute(&fish)
-        .args(&["-c", "fisher update"])
-        .check_run()?;
+    run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()?;
 
     run_type.execute(&fish).args(&["-c", "fisher"]).check_run()
 }


### PR DESCRIPTION
As of fisher 4.0.0 the user is expected to update fisher by installing
itself.

See: https://github.com/jorgebucaran/fisher/issues/594

This should fix: #556

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [ ] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
