### PR TITLE
Vim update: call DeinUpdate if available

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -19,4 +19,9 @@ if exists(":PackerUpdate")
     PackerSync
 endif
 
+if exists(":DeinUpdate")
+    echo "DeinUpdate"
+    DeinUpdate
+endif
+
 quitall


### PR DESCRIPTION
The project https://github.com/wsdjeg/dein-ui.vim provides a userfriendly alternative to the `call dein#upgrade` call of the dein plugin manager. If this command is available, we should run it

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles
- [X] The code passes rustfmt
- [X] The code passes clippy
- [X] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
