### PR TITLE
Add support for upgrading gcloud

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,7 @@ pub enum Step {
     Choosenim,
     Rtcl,
     Deno,
+    Gcloud,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Gem, "gem", || generic::run_gem(&base_dirs, run_type))?;
     runner.execute(Step::Sheldon, "sheldon", || generic::run_sheldon(&ctx))?;
     runner.execute(Step::Rtcl, "rtcl", || generic::run_rtcl(&ctx))?;
-    runner.execute(Step::Rtcl, "gcloud", || generic::run_gcloud_components_update(run_type))?;
+    runner.execute(Step::Gcloud, "gcloud", || {
+        generic::run_gcloud_components_update(run_type)
+    })?;
 
     #[cfg(target_os = "linux")]
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Gem, "gem", || generic::run_gem(&base_dirs, run_type))?;
     runner.execute(Step::Sheldon, "sheldon", || generic::run_sheldon(&ctx))?;
     runner.execute(Step::Rtcl, "rtcl", || generic::run_rtcl(&ctx))?;
+    runner.execute(Step::Rtcl, "gcloud", || generic::run_gcloud_components_update(run_type))?;
 
     #[cfg(target_os = "linux")]
     {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -113,6 +113,17 @@ pub fn run_krew_upgrade(run_type: RunType) -> Result<()> {
     run_type.execute(&krew).args(&["upgrade"]).check_run()
 }
 
+pub fn run_gcloud_components_update(run_type: RunType) -> Result<()> {
+    let gcloud = utils::require("gcloud")?;
+
+    print_separator("gcloud");
+
+    run_type
+        .execute(&gcloud)
+        .args(&["components", "update", "--quiet"])
+        .check_run()
+}
+
 pub fn run_jetpack(run_type: RunType) -> Result<()> {
     let jetpack = utils::require("jetpack")?;
 


### PR DESCRIPTION
gcloud is the command line tool for interacting with Google Cloud Platform. It's the CLI you can use to do typical tasks like creating new virtual servers. But you can also use it to install "components", like installing the `kubectl` command to interact with a Google Kubernetes Engine instance, or a local emulator for some of their closed-source products. So `gcloud components update` will check for updates on gcloud itself and any components you have installed. The `--quiet` flag skips confirmation, but it still outputs a changelog for the things that were updated.

I have tested that this runs the command like I expect and outputs properly, and that Topgrade understands that it was successful. Also, I've verified that if there are no updates available, it can determine that quickly and has sane output:

```
―― 12:29:50 - gcloud ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

All components are up to date.
```

And that it does not try to upgrade when `gcloud` is not in your `PATH`.

Thanks so much for this awesome project! I've been using it for quite a while and it was incredibly easy to add this support!

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed