### PR TITLE
Fixes issue with ohmyzsh returning 80 on a successful run

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,6 +1,6 @@
 //! Utilities for command execution
 use crate::error::TopgradeError;
-use crate::utils::Check;
+use crate::utils::{Check, CheckWithCodes};
 use anyhow::Result;
 use log::{debug, trace};
 use std::ffi::{OsStr, OsString};
@@ -166,6 +166,12 @@ impl Executor {
     pub fn check_run(&mut self) -> Result<()> {
         self.spawn()?.wait()?.check()
     }
+
+    /// An extension of `check_run` that allows you to set a sequence of codes
+    /// that can indicate success of a script
+    pub fn check_run_with_codes(&mut self, codes: &[i32]) -> Result<()> {
+        self.spawn()?.wait()?.check_with_codes(codes)
+    }
 }
 
 pub enum ExecutorOutput {
@@ -227,6 +233,15 @@ impl Check for ExecutorExitStatus {
     fn check(self) -> Result<()> {
         match self {
             ExecutorExitStatus::Wet(e) => e.check(),
+            ExecutorExitStatus::Dry => Ok(()),
+        }
+    }
+}
+
+impl CheckWithCodes for ExecutorExitStatus {
+    fn check_with_codes(self, codes: &[i32]) -> Result<()> {
+        match self {
+            ExecutorExitStatus::Wet(e) => e.check_with_codes(codes),
             ExecutorExitStatus::Dry => Ok(()),
         }
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -169,6 +169,7 @@ impl Executor {
 
     /// An extension of `check_run` that allows you to set a sequence of codes
     /// that can indicate success of a script
+    #[allow(dead_code)]
     pub fn check_run_with_codes(&mut self, codes: &[i32]) -> Result<()> {
         self.spawn()?.wait()?.check_with_codes(codes)
     }

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -142,5 +142,5 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
         .execute("zsh")
         .env("ZSH", &oh_my_zsh)
         .arg(&oh_my_zsh.join("tools/upgrade.sh"))
-        .check_run()
+        .check_run_with_codes(&[80])
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,22 @@ impl Check for Output {
     }
 }
 
+pub trait CheckWithCodes {
+    fn check_with_codes(self, codes: &[i32]) -> Result<()>;
+}
+
+impl CheckWithCodes for ExitStatus {
+    fn check_with_codes(self, codes: &[i32]) -> Result<()> {
+        // Set the default to be -1 because the option represents a signal termination
+        let code = self.code().unwrap_or(-1);
+        if self.success() || codes.contains(&code) {
+            Ok(())
+        } else {
+            Err(TopgradeError::ProcessFailed(self).into())
+        }
+    }
+}
+
 pub trait PathExt
 where
     Self: Sized,


### PR DESCRIPTION
* Fixes #569
* Mostly made this for fun. Not sure if this is the best way to handle the situation, I don't have too much experience with OSS. 
* Adds a new that allows you to specify output codes that are valid for a given script.
* Also fixes issue with oh-my-zsh spitting out an 80 output if no changes were made

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles
- [X] The code passes rustfmt
- [X] The code passes clippy
- [X] The code passes tests
- [X] *Optional:* I have tested the code myself
    - [X] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
