### PR TITLE
Removes unnecessary duplication with a blanket implementation

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -230,15 +230,6 @@ pub enum ExecutorExitStatus {
     Dry,
 }
 
-impl Check for ExecutorExitStatus {
-    fn check(self) -> Result<()> {
-        match self {
-            ExecutorExitStatus::Wet(e) => e.check(),
-            ExecutorExitStatus::Dry => Ok(()),
-        }
-    }
-}
-
 impl CheckWithCodes for ExecutorExitStatus {
     fn check_with_codes(self, codes: &[i32]) -> Result<()> {
         match self {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,16 +12,6 @@ pub trait Check {
     fn check(self) -> Result<()>;
 }
 
-impl Check for ExitStatus {
-    fn check(self) -> Result<()> {
-        if self.success() {
-            Ok(())
-        } else {
-            Err(TopgradeError::ProcessFailed(self).into())
-        }
-    }
-}
-
 impl Check for Output {
     fn check(self) -> Result<()> {
         self.status.check()
@@ -30,6 +20,14 @@ impl Check for Output {
 
 pub trait CheckWithCodes {
     fn check_with_codes(self, codes: &[i32]) -> Result<()>;
+}
+
+// Anything that implements CheckWithCodes also implements check
+// if check_with_codes is given an empty array of codes to check
+impl<T: CheckWithCodes> Check for T {
+    fn check(self) -> Result<()> {
+        self.check_with_codes(&[])
+    }
 }
 
 impl CheckWithCodes for ExitStatus {


### PR DESCRIPTION
This one isn't entirely necessary, but it eliminates some of the duplication created by my previous PR.

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles
- [X] The code passes rustfmt
- [X] The code passes clippy
- [X] The code passes tests
- [X] *Optional:* I have tested the code myself
    - [X] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
