### PR TITLE
Enable distro-sync in Fedora (fix #587)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -69,6 +69,7 @@
 #enable_tlmgr = true
 #emerge_sync_flags = "-q"
 #emerge_update_flags = "-uDNa --with-bdeps=y world"
+#redhat_disrto_sync = false
 
 [windows]
 # Manually select Windows updates

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,6 +153,7 @@ pub struct Linux {
     trizen_arguments: Option<String>,
     dnf_arguments: Option<String>,
     enable_tlmgr: Option<bool>,
+    redhat_distro_sync: Option<bool>,
     emerge_sync_flags: Option<String>,
     emerge_update_flags: Option<String>,
 }
@@ -627,13 +628,23 @@ impl Config {
             .and_then(|vagrant| vagrant.always_suspend)
     }
 
-    /// Extra yay arguments
+    /// Enable tlmgr on Linux
     #[allow(dead_code)]
     pub fn enable_tlmgr_linux(&self) -> bool {
         self.config_file
             .linux
             .as_ref()
             .and_then(|linux| linux.enable_tlmgr)
+            .unwrap_or(false)
+    }
+
+    /// Use distro-sync in Red Hat based distrbutions
+    #[allow(dead_code)]
+    pub fn redhat_distro_sync(&self) -> bool {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|linux| linux.redhat_distro_sync)
             .unwrap_or(false)
     }
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -249,7 +249,11 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
                     .if_exists()
                     .unwrap_or_else(|| Path::new("/usr/bin/yum")),
             )
-            .arg("upgrade");
+            .arg(if ctx.config().redhat_distro_sync() {
+                "distro-sync"
+            } else {
+                "upgrade"
+            });
 
         if let Some(args) = ctx.config().dnf_arguments() {
             command.args(args.split_whitespace());


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
