### PR TITLE
Fix Brew Cask step argument order

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -125,7 +125,7 @@ pub fn run_brew_cask(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()>
             brew_args.push("-a");
         }
     } else {
-        brew_args.extend(&["--cask", "upgrade"]);
+        brew_args.extend(&["upgrade", "--cask"]);
         if ctx.config().brew_cask_greedy() {
             brew_args.push("--greedy");
         }


### PR DESCRIPTION
Noticed new Brew Cask step failing after upgrading topgrade.

Fix was to switch args from `brew --cask upgrade` to `brew upgrade --cask`

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

