### PR TITLE
Skip dotnet when no SDK is installed (fix #592)

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -302,12 +302,15 @@ pub fn run_composer_update(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let dotnet = utils::require("dotnet")?;
 
-    let output = Command::new(dotnet)
-        .args(&["tool", "list", "--global"])
-        .check_output()?;
+    let output = Command::new(dotnet).args(&["tool", "list", "--global"]).output()?;
 
+    if !output.status.success() {
+        return Err(SkipStep(format!("dotnet failed with exit code {:?}", output.status)).into());
+    }
+
+    let output = String::from_utf8(output.stdout)?;
     if !output.starts_with("Package Id") {
-        return Err(SkipStep(String::from("dotnet does not output packages")).into());
+        return Err(SkipStep(String::from("dotnet did not output packages")).into());
     }
 
     let mut packages = output.split('\n').skip(2).filter(|line| !line.is_empty()).peekable();

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -306,6 +306,10 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
         .args(&["tool", "list", "--global"])
         .check_output()?;
 
+    if !output.starts_with("Package Id") {
+        return Err(SkipStep(String::from("dotnet does not output packages")).into());
+    }
+
     let mut packages = output.split('\n').skip(2).filter(|line| !line.is_empty()).peekable();
 
     if packages.peek().is_none() {


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
