### PR TITLE
Resolves an issue `fisher` failing 

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -72,7 +72,7 @@ pub fn run_fisher(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
 
     print_separator("Fisher");
 
-    run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()
+    run_type.execute(&fish).args(&["-c", "fisher"]).check_run()
 }
 
 pub fn run_oh_my_fish(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
The command `fisher update` is no longer supported by Fisher.
To update Fisher the command is now `fisher` 

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
