### PR TITLE
Launch bash to find topgrade in WSL (fix #612)

### DIFF
--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -53,7 +53,7 @@ pub fn run_scoop(cleanup: bool, run_type: RunType) -> Result<()> {
 pub fn run_wsl_topgrade(ctx: &ExecutionContext) -> Result<()> {
     let wsl = require("wsl")?;
     let topgrade = Command::new(&wsl)
-        .args(&["which", "topgrade"])
+        .args(&["bash", "-c", "which topgrade"])
         .check_output()
         .map_err(|_| SkipStep(String::from("Could not find Topgrade installed in WSL")))?;
 


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
