### PR TITLE
Support globally installed oh-my-zsh (fix #611)

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -102,7 +102,12 @@ pub fn run_zim(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
 
 pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
     require("zsh")?;
-    let oh_my_zsh = ctx.base_dirs().home_dir().join(".oh-my-zsh").require()?;
+    let oh_my_zsh = ctx
+        .base_dirs()
+        .home_dir()
+        .join(".oh-my-zsh")
+        .require()
+        .or_else(|_| PathBuf::from("/usr/share/oh-my-zsh").require())?;
 
     print_separator("oh-my-zsh");
 


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
