### PR TITLE
Surpress explicit news printing when paru is used

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -157,13 +157,14 @@ fn upgrade_arch_linux(ctx: &ExecutionContext) -> Result<()> {
     debug!("Running Arch update with path: {:?}", path);
 
     if let Some(yay) = which("yay").or_else(|| which("paru")) {
-        run_type
-            .execute(&yay)
-            .arg("-Pw")
-            .spawn()
-            .and_then(|mut p| p.wait())
-            .ok();
-
+        if yay.ends_with("yay") {
+            run_type
+                .execute(&yay)
+                .arg("-Pw")
+                .spawn()
+                .and_then(|mut p| p.wait())
+                .ok();
+        }
         let mut command = run_type.execute(&yay);
 
         command

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -156,15 +156,17 @@ fn upgrade_arch_linux(ctx: &ExecutionContext) -> Result<()> {
     };
     debug!("Running Arch update with path: {:?}", path);
 
-    if let Some(yay) = which("yay").or_else(|| which("paru")) {
-        if yay.ends_with("yay") {
-            run_type
-                .execute(&yay)
-                .arg("-Pw")
-                .spawn()
-                .and_then(|mut p| p.wait())
-                .ok();
-        }
+    let yay = which("yay");
+    if let Some(yay) = &yay {
+        run_type
+            .execute(&yay)
+            .arg("-Pw")
+            .spawn()
+            .and_then(|mut p| p.wait())
+            .ok();
+    }
+
+    if let Some(yay) = yay.or_else(|| which("paru")) {
         let mut command = run_type.execute(&yay);
 
         command


### PR DESCRIPTION
This is just a small change which supresses the fetching of arch news when paru is used, since it is done automatically when  `paru` is executed. I am not that well versed in rust, hope it is still an okayish way to do this.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed