### PR TITLE
Fix: Neovim may use init.vim or init.lua

### DIFF
--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -34,7 +34,10 @@ fn nvimrc(base_dirs: &BaseDirs) -> Result<PathBuf> {
     #[cfg(windows)]
     let base_dir = base_dirs.cache_dir();
 
-    base_dir.join("nvim/init.vim").require()
+    base_dir
+        .join("nvim/init.vim")
+        .require()
+        .or_else(|_| base_dir.join("nvim/init.lua").require())
 }
 
 fn upgrade(vim: &PathBuf, vimrc: &PathBuf, ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
This PR adds support for the Neovim step for users which use `init.lua` in lieu of `init.vim` for configuration. It only adds a fallback check for the appropriate path; nothing else in the Neovim step has been changed.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed