### PR TITLE
Add plugin support for the micro text editor

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,7 @@ pub enum Step {
     Jetpack,
     Krew,
     MacPorts,
+    Micro,
     MicrosoftAutoUpdate,
     Myrepos,
     Nix,

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,6 +309,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Gcloud, "gcloud", || {
         generic::run_gcloud_components_update(run_type)
     })?;
+    runner.execute(Step::Micro, "micro", || generic::run_micro(run_type))?;
 
     #[cfg(target_os = "linux")]
     {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use directories::BaseDirs;
 use log::debug;
 use std::env;
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::tempfile_in;
@@ -99,6 +100,21 @@ pub fn run_vscode(run_type: RunType) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn run_micro(run_type: RunType) -> Result<()> {
+    let micro = utils::require("micro")?;
+
+    print_separator("micro");
+
+    let stdout = run_type.execute(&micro).args(&["-plugin", "update"]).string_output()?;
+    std::io::stdout().write_all(&stdout.as_bytes())?;
+
+    if stdout.contains("Nothing to install / update") || stdout.contains("One or more plugins installed") {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("micro output does not indicate success: {}", stdout))
+    }
 }
 
 #[cfg(not(any(


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [*] I also tested that Topgrade skips the step where needed: *kind of, by giving `utils::require` a wrong binary name*

---

This PR adds support for plugins for [micro](https://micro-editor.github.io/) via its built-in `-plugin update` command.

Unfortunately I have to check micro's stdout, because even if it fails, micro returns exit code 0. See https://github.com/zyedidia/micro/issues/1647


**Excerpts:**

Normal run:
```
❯ cargo run -- --only micro             
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/topgrade --only micro`

―― 14:48:36 - micro ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
Checking for plugin updates
Nothing to install / update

―― 14:48:36 - Summary ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
micro: OK
```

Without internet:
```
❯ cargo run -- --only micro 
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/topgrade --only micro`

―― 14:49:20 - micro ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
Checking for plugin updates
Failed to query plugin channel:
 Get "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/channel.json": dial tcp: lookup raw.githubusercontent.com: no such host
unable to find a matching version for "fmt"

Retry? (y)es/(N)o/(s)hell

```
