### PR TITLE
Fix panic when dry running micro

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -110,12 +110,15 @@ pub fn run_vscode(run_type: RunType) -> Result<()> {
     Ok(())
 }
 
-pub fn run_micro(run_type: RunType) -> Result<()> {
+pub fn run_micro(_run_type: RunType) -> Result<()> {
     let micro = utils::require("micro")?;
 
     print_separator("micro");
 
-    let stdout = run_type.execute(&micro).args(&["-plugin", "update"]).string_output()?;
+    let stdout = RunType::Wet
+        .execute(&micro)
+        .args(&["-plugin", "update"])
+        .string_output()?;
     std::io::stdout().write_all(&stdout.as_bytes())?;
 
     if stdout.contains("Nothing to install / update") || stdout.contains("One or more plugins installed") {


### PR DESCRIPTION
Dry running `micro` would produce an error message similar to that in #632.

As of now, the `run_type` parameter is not used anywhere in the function and I've prefixed it with an underscore to keep the interface similar to other functions in the module. In case the parameter can be removed, let me know and I'll update it, or you can go ahead and make the necessary changes.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed
