### PR TITLE
Install VSCode extensions with a single command

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -100,12 +100,14 @@ pub fn run_vscode(run_type: RunType) -> Result<()> {
         .args(&["--list-extensions"])
         .check_output()?;
 
+    let mut args = vec!["--force"];
+
     for plugin in plugins.lines() {
-        run_type
-            .execute(&vscode)
-            .args(&["--force", "--install-extension", plugin])
-            .check_run()?;
+        args.push("--install-extension");
+        args.push(plugin);
     }
+
+    run_type.execute(&vscode).args(args).check_run()?;
 
     Ok(())
 }


### PR DESCRIPTION
closes #647

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed


Example output with `-v`
```
―― 09:32:34 - Visual Studio Code ―――――――――――――――――――――――――――――――――――――――――――――――
 2021-02-22T08:32:34.882Z DEBUG topgrade::executor   > Running "/usr/bin/code" "--force" "--install-extension" "alphabotsec.vscode-eclipse-keybindings" "--install-extension" "eamodio.gitlens" "--install-extension" "formulahendry.code-runner" "--install-extension" "ms-azuretools.vscode-docker" "--install-extension" "ms-python.python" "--install-extension" "muhammad-sammy.csharp" "--install-extension" "redhat.vscode-xml" "--install-extension" "redhat.vscode-yaml" "--install-extension" "rogalmic.bash-debug" "--install-extension" "rust-lang.rust" "--install-extension" "serayuzgur.crates" "--install-extension" "webfreak.debug" "--install-extension" "yzhang.markdown-all-in-one"
Installing extensions...
Extension 'serayuzgur.crates' is already installed.
Extension 'alphabotsec.vscode-eclipse-keybindings' is already installed.
Extension 'formulahendry.code-runner' is already installed.
Extension 'redhat.vscode-yaml' is already installed.
Extension 'rogalmic.bash-debug' is already installed.
Extension 'rust-lang.rust' is already installed.
Extension 'yzhang.markdown-all-in-one' is already installed.
Extension 'redhat.vscode-xml' is already installed.
Extension 'webfreak.debug' is already installed.
Extension 'ms-azuretools.vscode-docker' is already installed.
Extension 'ms-python.python' is already installed.
Extension 'muhammad-sammy.csharp' is already installed.
Extension 'eamodio.gitlens' is already installed.
```
