### PR TITLE
add support for paq-nvim

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -24,4 +24,9 @@ if exists(":DeinUpdate")
     DeinUpdate
 endif
 
+if exists(":PaqUpdate")
+    echo "PaqUpdate"
+    PaqUpdate
+endif
+
 quitall


### PR DESCRIPTION
this PR adds support for the neovim plugin manager [paq-nvim](https://github.com/savq/paq-nvim)

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles
- [x] The code passes rustfmt
- [x] The code passes clippy
- [x] The code passes tests
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
