### PR TITLE
Use go env GOPATH to determine the GOPATH

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -286,7 +286,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Choosenim, "choosenim", || generic::run_choosenim(&ctx))?;
     runner.execute(Step::Cargo, "cargo", || generic::run_cargo_update(run_type))?;
     runner.execute(Step::Flutter, "Flutter", || generic::run_flutter_upgrade(run_type))?;
-    runner.execute(Step::Go, "Go", || generic::run_go(&base_dirs, run_type))?;
+    runner.execute(Step::Go, "Go", || generic::run_go(run_type))?;
     runner.execute(Step::Emacs, "Emacs", || emacs.upgrade(run_type))?;
     runner.execute(Step::Opam, "opam", || generic::run_opam_update(run_type))?;
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(run_type))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -42,11 +42,9 @@ pub fn run_flutter_upgrade(run_type: RunType) -> Result<()> {
     run_type.execute(&flutter).arg("upgrade").check_run()
 }
 
-pub fn run_go(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
+pub fn run_go(run_type: RunType) -> Result<()> {
     let go = utils::require("go")?;
-    let gopath = env::var("GOPATH")
-        .unwrap_or_else(|_| base_dirs.home_dir().join("go").to_str().unwrap().to_string())
-        .require()?;
+    let gopath = run_type.execute(&go).args(&["env", "GOPATH"]).check_output()?;
 
     print_separator("Go");
     run_type


### PR DESCRIPTION
The GOPATH env variable usually is not set on any system because Go
uses its own env management via `go env` command.
Also `go env GOPATH` is not on all systems the same as `$HOME/go`.
On such systems topgrade would use the wrong GOPATH.

If the `go` command is installed then `go env GOPATH` will always print
something.
If GOPATH is set then `go env GOPATH` will print the value of GOPATH,
otherwise `go env GOPATH` will print the GOPATH value of the Go env
config.