### PR TITLE
Drop the Go step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -82,7 +82,6 @@ pub enum Step {
     Gcloud,
     Gem,
     GitRepos,
-    Go,
     HomeManager,
     Jetpack,
     Krew,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -101,6 +101,7 @@ impl Executor {
         self
     }
 
+    #[allow(dead_code)]
     /// See `std::process::Command::remove_env`
     pub fn env_remove<K>(&mut self, key: K) -> &mut Executor
     where

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,7 +286,6 @@ fn run() -> Result<()> {
     runner.execute(Step::Choosenim, "choosenim", || generic::run_choosenim(&ctx))?;
     runner.execute(Step::Cargo, "cargo", || generic::run_cargo_update(run_type))?;
     runner.execute(Step::Flutter, "Flutter", || generic::run_flutter_upgrade(run_type))?;
-    runner.execute(Step::Go, "Go", || generic::run_go(run_type))?;
     runner.execute(Step::Emacs, "Emacs", || emacs.upgrade(run_type))?;
     runner.execute(Step::Opam, "opam", || generic::run_opam_update(run_type))?;
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(run_type))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -42,19 +42,6 @@ pub fn run_flutter_upgrade(run_type: RunType) -> Result<()> {
     run_type.execute(&flutter).arg("upgrade").check_run()
 }
 
-pub fn run_go(run_type: RunType) -> Result<()> {
-    let go = utils::require("go")?;
-    let gopath = run_type.execute(&go).args(&["env", "GOPATH"]).check_output()?;
-
-    print_separator("Go");
-    run_type
-        .execute(&go)
-        .args(&["get", "-u", "all"])
-        .current_dir(gopath)
-        .env_remove("GO111MODULE")
-        .check_run()
-}
-
 pub fn run_gem(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let gem = utils::require("gem")?;
     base_dirs.home_dir().join(".gem").require()?;


### PR DESCRIPTION
With the release of Go 1.16 the behavior of `go get` has been changed.
In previous Go versions `go get` was used not only to add module
dependencies but also to install Go tools.
As of Go 1.16 `go get` can only add and upgrade module dependencies.
To install Go tools now the `go install` command has to be used.

Further on Go 1.16 enabled the GOMODULE mode by default and will drop
the GOPATH mode completly in Go 1.17.
So the package definition `all` like in `go get -u all` does not work
anymore if the PWD is outside of a Go module project.
Because of this `go list all` also does not work for the same reason.
That being said it seems that currently there is no way to get a list of
all installed Go tools or packages at the GOPATH level.

So the only possible solution to determine the installed Go tools and
also to update them would be by inspecting the `go env GOBIN` directory
as well as the `go env GOMODCACHE` sub-directories and to filter the
results according to their possible name-to-package boundaries.
As this approach seems to be very ugly and also not to be very safe or
stable and Go currently does not support any kind of automated upgrades
of installed Go tools it is best to drop the Go step for now until Go
implements some kind of Go tool upgrade feature.

Fixes #659