### PR TITLE
Execute the user default shell when using remotes (fix #670)

### DIFF
--- a/src/steps/remote/ssh.rs
+++ b/src/steps/remote/ssh.rs
@@ -17,7 +17,7 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
     }
 
     let env = format!("TOPGRADE_PREFIX={}", hostname);
-    args.extend(&["env", &env, topgrade]);
+    args.extend(&["env", &env, "$SHELL", "-lc", topgrade]);
 
     if ctx.config().yes() {
         args.push("-y");
@@ -45,7 +45,7 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
         }
 
         let env = format!("TOPGRADE_PREFIX={}", hostname);
-        args.extend(&["env", &env, topgrade]);
+        args.extend(&["env", &env, "$SHELL", "-lc", topgrade]);
 
         if ctx.config().yes() {
             args.push("-y");


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles
- [ ] The code passes rustfmt
- [ ] The code passes clippy
- [ ] The code passes tests
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
