### PR TITLE
makes rpm-ostree configurable

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -70,6 +70,7 @@
 #emerge_sync_flags = "-q"
 #emerge_update_flags = "-uDNa --with-bdeps=y world"
 #redhat_distro_sync = false
+#rpm_ostree = false
 
 [windows]
 # Manually select Windows updates

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,7 @@ pub struct Linux {
     apt_arguments: Option<String>,
     enable_tlmgr: Option<bool>,
     redhat_distro_sync: Option<bool>,
+    rpm_ostree: Option<bool>,
     emerge_sync_flags: Option<String>,
     emerge_update_flags: Option<String>,
 }
@@ -667,6 +668,16 @@ impl Config {
             .as_ref()
             .and_then(|linux| linux.redhat_distro_sync)
             .unwrap_or(false)
+    }
+
+    /// Use rpm-ostree in *when rpm-ostree is detected* (default: true)
+    #[allow(dead_code)]
+    pub fn rpm_ostree(&self) -> bool {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|linux| linux.rpm_ostree)
+            .unwrap_or(true)
     }
 
     /// Should we ignore failures for this step

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -237,15 +237,17 @@ fn upgrade_arch_linux(ctx: &ExecutionContext) -> Result<()> {
 }
 
 fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
-    if let Some(ostree) = Path::new("/usr/bin/rpm-ostree").if_exists() {
-        let mut command = ctx.run_type().execute(ostree);
-        command.arg("upgrade");
-        if ctx.config().yes() {
-            command.arg("-y");
-        }
+    let _ = if let Some(ostree) = Path::new("/usr/bin/rpm-ostree").if_exists() {
+        if ctx.config().rpm_ostree() {
+            let mut command = ctx.run_type().execute(ostree);
+            command.arg("upgrade");
+            if ctx.config().yes() {
+                command.arg("-y");
+            }
 
-        return command.check_run();
-    }
+            return command.check_run();
+        }
+    };
 
     if let Some(sudo) = &ctx.sudo() {
         let mut command = ctx.run_type().execute(&sudo);


### PR DESCRIPTION
This commit makes it possible to *not* to use `rpm-ostree` even on
systems where it is detected.

This commit is fully backwards compatible with previous releases, and
without changing the config file all previous behaviors are the exact
same.

This commit adds the `rpm_ostree` field in the `[linux]` table of the
configuration, and defaults to `true`. This means Topgrade will first
check if `/usr/bin/rpm-ostree` exists, and only if so then check if the
user does not want to use `rpm-ostree` via the configuration. If the
user *does not* want to use `rpm-ostree`, then normal operation
continues checking for DNF or YUM.

This makes it possible for people where `rpm-ostree` is installed, but
where the system is not an `ostree` based distribtuion. This happens
when people are using things like `osbuild-composer` to build images,
or Cockpit with the Compose feature enabled (which uses
`osbuild-composer` internally).

An alternative to this commit would be to make the config field a
negative such as `no_rpm_ostree`, however that goes against the norm in
other fields.

Closes #710

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
