### PR TITLE
Add bin support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,7 @@ pub enum Step {
     Atom,
     BrewCask,
     BrewFormula,
+    Bin,
     Cargo,
     Chocolatey,
     Choosenim,

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,6 +301,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Gem, "gem", || generic::run_gem(&base_dirs, run_type))?;
     runner.execute(Step::Sheldon, "sheldon", || generic::run_sheldon(&ctx))?;
     runner.execute(Step::Rtcl, "rtcl", || generic::run_rtcl(&ctx))?;
+    runner.execute(Step::Bin, "bin", || generic::bin_update(&ctx))?;
     runner.execute(Step::Gcloud, "gcloud", || {
         generic::run_gcloud_components_update(run_type)
     })?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -379,3 +379,10 @@ pub fn run_raco_update(run_type: RunType) -> Result<()> {
 
     run_type.execute(&raco).args(&["pkg", "update", "--all"]).check_run()
 }
+
+pub fn bin_update(ctx: &ExecutionContext) -> Result<()> {
+    let bin = utils::require("bin")?;
+
+    print_separator("Bin");
+    ctx.run_type().execute(&bin).arg("update").check_run()
+}


### PR DESCRIPTION
This PR adds support to manage [bin](https://github.com/marcosnils/bin) updates

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
