### PR TITLE
PIP: avoid the warning 'pip is being invoked by an old script wrapper'

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -203,12 +203,12 @@ pub fn run_pipx_update(run_type: RunType) -> Result<()> {
 }
 
 pub fn run_pip3_update(run_type: RunType) -> Result<()> {
-    let pip3 = utils::require("pip3")?;
+    let python3 = utils::require("python3")?;
     print_separator("pip3");
 
     run_type
-        .execute(&pip3)
-        .args(&["install", "--upgrade", "--user", "pip"])
+        .execute(&python3)
+        .args(&["-m", "pip", "install", "--upgrade", "--user", "pip"])
         .check_run()
 }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

## Short explanation

Under certain circumstances, e.g. on macOS 12, invoking `pip3` produces the following warning: `WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip. Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue. To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.`