### PR TITLE
Adding pnpm support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Vim, "voom", || vim::run_voom(&base_dirs, run_type))?;
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&ctx))?;
     runner.execute(Step::Node, "yarn", || node::yarn_global_update(run_type))?;
+    runner.execute(Step::Node, "pnpm", || node::pnpm_global_update(run_type))?;
     runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;
     runner.execute(Step::Composer, "composer", || generic::run_composer_update(&ctx))?;
     runner.execute(Step::Krew, "krew", || generic::run_krew_upgrade(run_type))?;

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -80,6 +80,13 @@ pub fn run_npm_upgrade(ctx: &ExecutionContext) -> Result<()> {
     npm.upgrade(ctx.run_type(), use_sudo)
 }
 
+pub fn pnpm_global_update(run_type: RunType) -> Result<()> {
+    let pnpm = require("pnpm")?;
+
+    print_separator("Performant Node Package Manager");
+    run_type.execute(&pnpm).args(&["update", "-g"]).check_run()
+}
+
 pub fn yarn_global_update(run_type: RunType) -> Result<()> {
     let yarn = require("yarn")?;
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Adds support for [pnpm](https://github.com/pnpm/pnpm) global update.

2 questions:
- Should I check like for `npm` if `pnpm root -g` inside the user's home directory ? Like `yarn`, the default global directory is located at `~/pnpm-global`, so I don't think this shoud be necessary.
- Should I add the `--silent` flag ? I prefer without it to see what's going on, but maybe it's better if silent.

Thanks for this super useful program! 
