### PR TITLE
Allow to run `flatpak update` with sudo

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -89,3 +89,7 @@
 [firmware]
 # Offer to update firmware; if false just check for and display available updates
 #upgrade = true
+
+[flatpak]
+# Use sudo for updating the system-wide installation
+#use_sudo = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,13 @@ pub struct Firmware {
 
 #[derive(Deserialize, Default, Debug)]
 #[serde(deny_unknown_fields)]
+#[allow(clippy::upper_case_acronyms)]
+pub struct Flatpak {
+    use_sudo: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Brew {
     greedy_cask: Option<bool>,
 }
@@ -221,6 +228,7 @@ pub struct ConfigFile {
     npm: Option<NPM>,
     firmware: Option<Firmware>,
     vagrant: Option<Vagrant>,
+    flatpak: Option<Flatpak>,
 }
 
 fn config_directory(base_dirs: &BaseDirs) -> PathBuf {
@@ -744,6 +752,15 @@ impl Config {
             .firmware
             .as_ref()
             .and_then(|firmware| firmware.upgrade)
+            .unwrap_or(false)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn flatpak_use_sudo(&self) -> bool {
+        self.config_file
+            .flatpak
+            .as_ref()
+            .and_then(|flatpak| flatpak.use_sudo)
             .unwrap_or(false)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,7 @@ fn run() -> Result<()> {
 
     #[cfg(target_os = "linux")]
     {
-        runner.execute(Step::Flatpak, "Flatpak", || linux::flatpak_update(run_type))?;
+        runner.execute(Step::Flatpak, "Flatpak", || linux::flatpak_update(&ctx))?;
         runner.execute(Step::Snap, "snap", || linux::run_snap(sudo.as_ref(), run_type))?;
     }
 


### PR DESCRIPTION
This change adds the option `flatpak.use_sudo` that allows to update the system-wide installation with sudo. When set to `true` the system-wide installation will be updated with sudo. If set to `false` (default) the update will be run as regular user.

This solves the problem where running `flatpak update` on a remote system fails if run as regular user.

Fixes #737.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
