### PR TITLE
Make firmware upgrade configurable

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -88,4 +88,4 @@
 
 [firmware]
 # Offer to update firmware; if false just check for and display available updates
-#upgrade = false
+#upgrade = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -85,3 +85,7 @@
 [npm]
 # Use sudo if the NPM directory isn't owned by the current user
 #use_sudo = true
+
+[firmware]
+# Offer to update firmware; if false just check for and display available updates
+#upgrade = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,13 @@ pub struct NPM {
 
 #[derive(Deserialize, Default, Debug)]
 #[serde(deny_unknown_fields)]
+#[allow(clippy::upper_case_acronyms)]
+pub struct Firmware {
+    upgrade: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Brew {
     greedy_cask: Option<bool>,
 }
@@ -212,6 +219,7 @@ pub struct ConfigFile {
     git: Option<Git>,
     windows: Option<Windows>,
     npm: Option<NPM>,
+    firmware: Option<Firmware>,
     vagrant: Option<Vagrant>,
 }
 
@@ -728,6 +736,15 @@ impl Config {
             .as_ref()
             .and_then(|npm| npm.use_sudo)
             .unwrap_or(false)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn firmware_upgrade(&self) -> bool {
+        self.config_file
+            .firmware
+            .as_ref()
+            .and_then(|firmware| firmware.upgrade)
+            .unwrap_or(true)
     }
 
     #[cfg(target_os = "linux")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -744,7 +744,7 @@ impl Config {
             .firmware
             .as_ref()
             .and_then(|firmware| firmware.upgrade)
-            .unwrap_or(true)
+            .unwrap_or(false)
     }
 
     #[cfg(target_os = "linux")]

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -521,13 +521,17 @@ pub fn run_fwupdmgr(ctx: &ExecutionContext) -> Result<()> {
         .arg("refresh")
         .check_run_with_codes(&[2])?;
 
-    let mut upgrade = ctx.run_type().execute(&fwupdmgr);
+    let mut updmgr = ctx.run_type().execute(&fwupdmgr);
 
-    upgrade.arg("update");
-    if ctx.config().yes() {
-        upgrade.arg("-y");
+    if ctx.config().firmware_upgrade() {
+        updmgr.arg("update");
+        if ctx.config().yes() {
+            updmgr.arg("-y");
+        }
+    } else {
+        updmgr.arg("get-updates");
     }
-    upgrade.check_run_with_codes(&[2])
+    updmgr.check_run_with_codes(&[2])
 }
 
 pub fn flatpak_update(run_type: RunType) -> Result<()> {


### PR DESCRIPTION
This change adds an option, `firmware.upgrade`, that if set to `false` only checks for and displays available firmware updates. If set to `true` (default) the user is offered to run the firmware upgrade.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
