### PR TITLE
Adds support for chezmoi

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,7 @@ pub enum Step {
     BrewFormula,
     Bin,
     Cargo,
+    Chezmoi,
     Chocolatey,
     Choosenim,
     Composer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Myrepos, "myrepos", || {
         generic::run_myrepos_update(&base_dirs, run_type)
     })?;
+    runner.execute(Step::Chezmoi, "chezmoi", || {
+        generic::run_chezmoi_update(&base_dirs, run_type)
+    })?;
     runner.execute(Step::Jetpack, "jetpack", || generic::run_jetpack(run_type))?;
     runner.execute(Step::Vim, "vim", || vim::upgrade_vim(&base_dirs, &ctx))?;
     runner.execute(Step::Vim, "Neovim", || vim::upgrade_neovim(&base_dirs, &ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -274,14 +274,8 @@ pub fn run_chezmoi_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()>
 
     print_separator("chezmoi");
 
-    run_type
-        .execute(&chezmoi)
-        .arg("update")
-        .check_run()?;
-    run_type
-        .execute(&chezmoi)
-        .arg("update")
-        .check_run()
+    run_type.execute(&chezmoi).arg("update").check_run()?;
+    run_type.execute(&chezmoi).arg("update").check_run()
 }
 
 pub fn run_myrepos_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -274,7 +274,6 @@ pub fn run_chezmoi_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()>
 
     print_separator("chezmoi");
 
-    run_type.execute(&chezmoi).arg("update").check_run()?;
     run_type.execute(&chezmoi).arg("update").check_run()
 }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -268,6 +268,22 @@ pub fn run_tlmgr_update(ctx: &ExecutionContext) -> Result<()> {
     command.check_run()
 }
 
+pub fn run_chezmoi_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
+    let chezmoi = utils::require("chezmoi")?;
+    base_dirs.home_dir().join(".local/share/chezmoi").require()?;
+
+    print_separator("chezmoi");
+
+    run_type
+        .execute(&chezmoi)
+        .arg("update")
+        .check_run()?;
+    run_type
+        .execute(&chezmoi)
+        .arg("update")
+        .check_run()
+}
+
 pub fn run_myrepos_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let myrepos = utils::require("mr")?;
     base_dirs.home_dir().join(".mrconfig").require()?;


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles (`cargo build`)
- [X] The code passes rustfmt (`cargo fmt`)
- [X] The code passes clippy (`cargo clippy`)
- [X] The code passes tests (`cargo test`)
- [X] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

This adds support for a new step of [chezmoi](https://github.com/twpayne/chezmoi), a dotfile manager for managing all of your precious dotfiles