### PR TITLE
Add Android/Termux support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,9 @@ fn run() -> Result<()> {
         freebsd::upgrade_packages(sudo.as_ref(), run_type)
     })?;
 
+    #[cfg(target_os = "android")]
+    runner.execute(Step::Pkg, "Termux Packages", || android::upgrade_packages(&ctx))?;
+
     let emacs = emacs::Emacs::new(&base_dirs);
     if config.use_predefined_git_repos() {
         if config.should_run(Step::Emacs) {

--- a/src/steps/os/android.rs
+++ b/src/steps/os/android.rs
@@ -1,0 +1,31 @@
+use crate::execution_context::ExecutionContext;
+use crate::terminal::print_separator;
+use crate::utils::require;
+use anyhow::Result;
+
+pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
+    let pkg = require("pkg")?;
+
+    print_separator("Termux Packages");
+
+    let mut command = ctx.run_type().execute(&pkg);
+    command.arg("upgrade");
+    if ctx.config().yes() {
+        command.arg("-y");
+    }
+    command.check_run()?;
+
+    if ctx.config().cleanup() {
+        ctx.run_type().execute(&pkg).arg("clean").check_run()?;
+
+        let apt = require("apt")?;
+        let mut command = ctx.run_type().execute(&apt);
+        command.arg("autoremove");
+        if ctx.config().yes() {
+            command.arg("-y");
+        }
+        command.check_run()?;
+    }
+
+    Ok(())
+}

--- a/src/steps/os/mod.rs
+++ b/src/steps/os/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "android")]
+pub mod android;
 #[cfg(target_os = "dragonfly")]
 pub mod dragonfly;
 #[cfg(target_os = "freebsd")]


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself _(manually, not through code)_
    - [x] I also tested that Topgrade skips the step where needed

This PR adds support for Android, more specifically [Termux](https://termux.com/), a very popular terminal emulator and Linux environment. It updates Termux packages (using `pkg` and `apt`) and other already supported UNIX tools (on my device, that meant `cargo`, `npm`, `nvim`, `yadm`, `git repositories`, `tmux` (`TPM`) and `pip3`). It also correctly started in a new `tmux` session, if that config is enabled.

Building is done with `cargo build --target aarch64-linux-android`.

I have one question: rebooting is not useful in this case and only works on rooted devices anyway, should the code be modified to remove this option on Android?

Let me know if there is anything that can or should be improved.
