### PR TITLE
Skip deno upgrade unless installed under .deno

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Vim, "voom", || vim::run_voom(&base_dirs, run_type))?;
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&ctx))?;
     runner.execute(Step::Pnpm, "pnpm", || node::pnpm_global_update(run_type))?;
-    runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;
+    runner.execute(Step::Deno, "deno", || node::deno_upgrade(&base_dirs, &ctx))?;
     runner.execute(Step::Composer, "composer", || generic::run_composer_update(&ctx))?;
     runner.execute(Step::Krew, "krew", || generic::run_krew_upgrade(run_type))?;
     runner.execute(Step::Gem, "gem", || generic::run_gem(&base_dirs, run_type))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Vim, "voom", || vim::run_voom(&base_dirs, run_type))?;
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&ctx))?;
     runner.execute(Step::Pnpm, "pnpm", || node::pnpm_global_update(run_type))?;
-    runner.execute(Step::Deno, "deno", || node::deno_upgrade(&base_dirs, &ctx))?;
+    runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;
     runner.execute(Step::Composer, "composer", || generic::run_composer_update(&ctx))?;
     runner.execute(Step::Krew, "krew", || generic::run_krew_upgrade(run_type))?;
     runner.execute(Step::Gem, "gem", || generic::run_gem(&base_dirs, run_type))?;

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -87,9 +87,9 @@ pub fn pnpm_global_update(run_type: RunType) -> Result<()> {
     run_type.execute(&pnpm).args(&["update", "-g"]).check_run()
 }
 
-pub fn deno_upgrade(base_dirs: &BaseDirs, ctx: &ExecutionContext) -> Result<()> {
+pub fn deno_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let deno = require("deno")?;
-    let deno_dir = base_dirs.home_dir().join(".deno");
+    let deno_dir = ctx.base_dirs().home_dir().join(".deno");
 
     if !deno.canonicalize()?.is_descendant_of(&deno_dir) {
         let skip_reason = SkipStep("Deno installed outside of .deno directory".to_string());

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -87,8 +87,14 @@ pub fn pnpm_global_update(run_type: RunType) -> Result<()> {
     run_type.execute(&pnpm).args(&["update", "-g"]).check_run()
 }
 
-pub fn deno_upgrade(ctx: &ExecutionContext) -> Result<()> {
+pub fn deno_upgrade(base_dirs: &BaseDirs, ctx: &ExecutionContext) -> Result<()> {
     let deno = require("deno")?;
+    let deno_dir = base_dirs.home_dir().join(".deno");
+
+    if !deno.canonicalize()?.is_descendant_of(&deno_dir) {
+        let skip_reason = SkipStep("Deno installed outside of .deno directory".to_string());
+        return Err(skip_reason.into());
+    }
 
     print_separator("Deno");
     ctx.run_type().execute(&deno).arg("upgrade").check_run()


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Deno can be installed from cargo or arch linux's repositories, so upgrade should only be called for user-wide shell-script installations.
