### PR TITLE
Fix: Correctly run asynchronous PackerSync

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -16,7 +16,12 @@ endif
 
 if exists(":PackerUpdate")
     echo "Packer"
+    augroup TOPGRADE_AUCMDS
+      au!
+      autocmd User PackerComplete quitall
+    augroup END
     PackerSync
+    finish
 endif
 
 if exists(":DeinUpdate")


### PR DESCRIPTION
`PackerSync` runs asynchronously, so it needs a slightly more complex setup than some other plugin managers in order to ensure that Neovim stays open until the operation completes. This PR adds that setup by changing, just for the case that `packer` is detected, the trigger for `quitall` to be a user autocommand that `packer` emits when its operations complete.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
