### PR TITLE
Remove date and version information from man page

### DIFF
--- a/topgrade.8
+++ b/topgrade.8
@@ -1,5 +1,5 @@
 .hy
-.TH "topgrade" "8" "29 Febuary 2020" "topgrade 4.1.1"
+.TH "topgrade" "8"
 .SH NAME
 .PP
 topgrade \- upgrade everything


### PR DESCRIPTION
It was confusing since it was outdated

## Standards checklist:

- [x] The PR title is descriptive.