### PR TITLE
add id_like for os detection of Alpine like distros (postmarketos  adelie linux)

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -69,6 +69,8 @@ impl Distribution {
                         return Ok(Distribution::Suse);
                     } else if id_like.contains(&"arch") || id_like.contains(&"archlinux") {
                         return Ok(Distribution::Arch);
+                    } else if id_like.contains(&"alpine") {
+                        return Ok(Distribution::Alpine);
                     } else if id_like.contains(&"fedora") {
                         return Ok(Distribution::Fedora);
                     }


### PR DESCRIPTION
tested to work with:
postmarketOS: https://postmarketos.org
should work with:
Adelielinux Linux: https://www.adelielinux.org

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
