### PR TITLE
Correct spelling for GNOME Shell extensions update

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -141,10 +141,10 @@ pub fn upgrade_gnome_extensions(ctx: &ExecutionContext) -> Result<()> {
             "call",
             "--session",
             "--dest",
-            "rg.gnome.Shell.Extensions",
+            "org.gnome.Shell.Extensions",
             "--object-path",
             "org/gnome/Shell/Extensions",
-            "-method",
+            "--method",
             "org.gnome.Shell.Extensions.CheckForUpdates",
         ])
         .check_run()


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
