### PR TITLE
fix gnome shell extensions update object path

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -143,7 +143,7 @@ pub fn upgrade_gnome_extensions(ctx: &ExecutionContext) -> Result<()> {
             "--dest",
             "org.gnome.Shell.Extensions",
             "--object-path",
-            "org/gnome/Shell/Extensions",
+            "/org/gnome/Shell/Extensions",
             "--method",
             "org.gnome.Shell.Extensions.CheckForUpdates",
         ])


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Fixes https://github.com/r-darwish/topgrade/issues/787 https://github.com/r-darwish/topgrade/issues/779
