### PR TITLE
fix: GNOME detection for customized version

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -134,7 +134,7 @@ pub fn run_fish_plug(ctx: &ExecutionContext) -> Result<()> {
 pub fn upgrade_gnome_extensions(ctx: &ExecutionContext) -> Result<()> {
     let gdbus = require("gdbus")?;
     require_option(
-        env::var("XDG_CURRENT_DESKTOP").ok().filter(|p| p == "GNOME"),
+        env::var("XDG_CURRENT_DESKTOP").ok().filter(|p| p.contains("GNOME")),
         "Desktop doest not appear to be gnome".to_string(),
     )?;
     print_separator("Gnome Shell extensions");


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.dev>

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Outputs:

```bash
echo $XDG_CURRENT_DESKTOP
pop:GNOME
```

Testing that gnome get's detected

```bash
./target/debug/topgrade --only gnome_shell_extensions

―― 11:05:19 - Gnome Shell extensions ―――――――――――――――――――――――――――――――――――――――――――
()

―― 11:05:19 - Summary ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
Gnome Shell Extensions: OK
```
Fixes: https://github.com/r-darwish/topgrade/issues/779#issuecomment-954435802
