### PR TITLE
Add new step pacdiff

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,7 @@ pub enum Step {
     Nix,
     Node,
     Opam,
+    Pacdiff,
     Pacstall,
     Pearl,
     Pipx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,8 @@ fn run() -> Result<()> {
             linux::run_etc_update(sudo.as_ref(), run_type)
         })?;
 
+        runner.execute(Step::Pacdiff, "pacdiff", || linux::run_pacdiff(sudo.as_ref(), run_type))?;
+
         runner.execute(Step::BrewFormula, "Brew", || {
             unix::run_brew_formula(&ctx, unix::BrewVariant::Linux)
         })?;

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -498,6 +498,15 @@ pub fn run_etc_update(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     run_type.execute(sudo).arg(etc_update).check_run()
 }
 
+pub fn run_pacdiff(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
+    let sudo = require_option(sudo, String::from("sudo is not installed"))?;
+    let pacdiff = require("pacdiff")?;
+
+    print_separator("pacdiff");
+
+    run_type.execute(sudo).arg(pacdiff).check_run()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR adds a step to execute [`pacdiff`](https://man.archlinux.org/man/pacdiff.8.en). It is run with `sudo` since it needs to edit files in `/etc` and it can be disabled.

Checks:
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

This PR closes #794 
