### PR TITLE
Add Support for Spicetify

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,7 @@ pub enum Step {
     Sheldon,
     Shell,
     Snap,
+    Spicetify,
     Stack,
     System,
     Tldr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,6 +324,7 @@ fn run() -> Result<()> {
     })?;
     runner.execute(Step::Micro, "micro", || generic::run_micro(run_type))?;
     runner.execute(Step::Raco, "raco", || generic::run_raco_update(run_type))?;
+    runner.execute(Step::Spicetify, "spicetify", || generic::spicetify_upgrade(&ctx))?;
 
     #[cfg(target_os = "linux")]
     {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -432,3 +432,10 @@ pub fn bin_update(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Bin");
     ctx.run_type().execute(&bin).arg("update").check_run()
 }
+
+pub fn spicetify_upgrade(ctx: &ExecutionContext) -> Result<()> {
+    let spicetify = utils::require("spicetify")?;
+
+    print_separator("Spicetify");
+    ctx.run_type().execute(&spicetify).arg("upgrade").check_run()
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Runs `spicetify upgrade` whenever `spicetify` is found in PATH, errors based on the command's status code. Closes #797

Just to be sure, can you test this? @CryoRenegade