### PR TITLE
Pacdiff doesn't need vim if $DIFFPROG is set

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -555,7 +555,7 @@ pub fn run_pacdiff(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("sudo is not installed"))?;
     let pacdiff = require("pacdiff")?;
 
-    if (env::var("DIFFPROG").is_err()) {
+    if std::env::var("DIFFPROG").is_err() {
         require("vim")?;
     }
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -554,7 +554,10 @@ pub fn run_etc_update(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
 pub fn run_pacdiff(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("sudo is not installed"))?;
     let pacdiff = require("pacdiff")?;
-    require("vim")?;
+
+    if (env::var("DIFFPROG").is_err()) {
+        require("vim")?;
+    }
 
     print_separator("pacdiff");
 


### PR DESCRIPTION
## Standards checklist:

closes #811

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

@PolpOnline 