### PR TITLE
Linux: System: Fix rpm-ostree detection

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -157,7 +157,7 @@ fn upgrade_alpine_linux(ctx: &ExecutionContext) -> Result<()> {
 }
 
 fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
-    let _ = if let Some(ostree) = Path::new("rpm-ostree").if_exists() {
+    if let Some(ostree) = which("rpm-ostree") {
         if ctx.config().rpm_ostree() {
             let mut command = ctx.run_type().execute(ostree);
             command.arg("upgrade");


### PR DESCRIPTION
On a rpm-ostree based system, topgrade would previously fail to detect
the rpm-ostree executable and fall back to yum instead, which isn't
available. This was caused by constructing a Path instance with
`Path::new`, rather than querying the underlying OS for a path to the
rpm-ostree executable.

Make the `system` update step use `which` to determine if an executable
called "rpm-ostree" is available on the system and get the correct path
to the executable.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

I developed this code myself.