### PR TITLE
Re-add the Go step via go-global-update

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,7 @@ pub enum Step {
     Gcloud,
     Gem,
     GitRepos,
+    Go,
     Haxelib,
     GnomeShellExtensions,
     HomeManager,

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Choosenim, "choosenim", || generic::run_choosenim(&ctx))?;
     runner.execute(Step::Cargo, "cargo", || generic::run_cargo_update(&ctx))?;
     runner.execute(Step::Flutter, "Flutter", || generic::run_flutter_upgrade(run_type))?;
+    runner.execute(Step::Go, "Go", || generic::run_go(run_type))?;
     runner.execute(Step::Emacs, "Emacs", || emacs.upgrade(&ctx))?;
     runner.execute(Step::Opam, "opam", || generic::run_opam_update(run_type))?;
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(run_type))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -60,6 +60,27 @@ pub fn run_flutter_upgrade(run_type: RunType) -> Result<()> {
     run_type.execute(&flutter).arg("upgrade").check_run()
 }
 
+pub fn run_go(run_type: RunType) -> Result<()> {
+    let go = utils::require("go")?;
+    let gopath = run_type.execute(&go).args(&["env", "GOPATH"]).check_output()?;
+
+    print_separator("Go");
+
+    let go_global_update = utils::require("go-global-update")
+        .ok()
+        .or_else(|| PathBuf::from(gopath).join("bin/go-global-update").if_exists());
+    let go_global_update = match go_global_update {
+        Some(e) => e,
+        None => {
+            let message = String::from("go-global-update isn't installed so Topgrade can't upgrade Go packages.\nInstall go-global-update by running `go install github.com/Gelio/go-global-update@latest`");
+            print_warning(&message);
+            return Err(SkipStep(message).into());
+        }
+    };
+
+    run_type.execute(&go_global_update).check_run()
+}
+
 pub fn run_gem(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let gem = utils::require("gem")?;
     base_dirs.home_dir().join(".gem").require()?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -64,19 +64,11 @@ pub fn run_go(run_type: RunType) -> Result<()> {
     let go = utils::require("go")?;
     let gopath = run_type.execute(&go).args(&["env", "GOPATH"]).check_output()?;
 
-    print_separator("Go");
-
     let go_global_update = utils::require("go-global-update")
-        .ok()
-        .or_else(|| PathBuf::from(gopath).join("bin/go-global-update").if_exists());
-    let go_global_update = match go_global_update {
-        Some(e) => e,
-        None => {
-            let message = String::from("go-global-update isn't installed so Topgrade can't upgrade Go packages.\nInstall go-global-update by running `go install github.com/Gelio/go-global-update@latest`");
-            print_warning(&message);
-            return Err(SkipStep(message).into());
-        }
-    };
+        .unwrap_or_else(|_| PathBuf::from(gopath).join("bin/go-global-update"))
+        .require()?;
+
+    print_separator("Go");
 
     run_type.execute(&go_global_update).check_run()
 }


### PR DESCRIPTION
go-global-update (https://github.com/Gelio/go-global-update) is a small
tool to update all executables installed in a user's GOBIN, effectively
providing a `go get -u all` replacement for Go 1.16+.

Since it appears that Go will not be receiving a built-in way to do this
in the near future, this could be a good option in the meantime.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
