### PR TITLE
fix: pacstall should run without yay arguments

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -323,16 +323,8 @@ fn upgrade_solus(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_pacstall(ctx: &ExecutionContext) -> Result<()> {
     let pacstall = require("pacstall")?;
-    ctx.run_type()
-        .execute(&pacstall)
-        .arg("-U")
-        .args(ctx.config().yay_arguments().split_whitespace())
-        .check_run()?;
-    ctx.run_type()
-        .execute(pacstall)
-        .arg("-Up")
-        .args(ctx.config().yay_arguments().split_whitespace())
-        .check_run()
+    ctx.run_type().execute(&pacstall).arg("-U").check_run()?;
+    ctx.run_type().execute(pacstall).arg("-Up").check_run()
 }
 
 fn upgrade_clearlinux(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
