### PR TITLE
linux: Ignore "--yes" for rpm-ostree upgrade

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -164,10 +164,6 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
         if ctx.config().rpm_ostree() {
             let mut command = ctx.run_type().execute(ostree);
             command.arg("upgrade");
-            if ctx.config().yes(Step::System) {
-                command.arg("-y");
-            }
-
             return command.check_run();
         }
     };


### PR DESCRIPTION
Previously when performing the "system" upgrade step, rpm-ostree would
be passed a "--yes" argument when it was configured in topgrade.
However, this is not an option available for rpm-ostree, so it would
cause an error and abort execution of the updates.

*Note Clippy doesn't pass, but that's due to an unused import unrelated to this PR*

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
