### PR TITLE
Upgrade podman/docker containers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,7 @@ pub enum Step {
     Composer,
     Conda,
     ConfigUpdate,
+    Containers,
     CustomCommands,
     Deno,
     Dotnet,

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,6 +311,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Kakoune, "Kakoune", || kakoune::upgrade_kak_plug(&ctx))?;
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&ctx))?;
     runner.execute(Step::Pnpm, "pnpm", || node::pnpm_global_update(&ctx))?;
+    runner.execute(Step::Containers, "Containers", || containers::run_containers(&ctx))?;
     runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;
     runner.execute(Step::Composer, "composer", || generic::run_composer_update(&ctx))?;
     runner.execute(Step::Krew, "krew", || generic::run_krew_upgrade(run_type))?;

--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+
+use crate::error;
+use crate::terminal::print_separator;
+use crate::{execution_context::ExecutionContext, utils::require};
+use log::debug;
+use std::path::Path;
+use std::process::Command;
+
+/// Returns a Vector of all containers, with Strings in the format
+/// "REGISTRY/[PATH/]CONTAINER_NAME:TAG"
+fn list_containers(crt: &Path) -> Result<Vec<String>> {
+    let output = Command::new(crt)
+        .args(&["images", "--format", "{{.Repository}}:{{.Tag}}"])
+        .output()?;
+    let output_str = String::from_utf8(output.stdout)?;
+
+    let mut retval = vec![];
+    for line in output_str.lines() {
+        if line.starts_with("localhost") {
+            // Don't know how to update self-built containers
+            debug!("Skipping self-built container '{}'", line);
+            continue;
+        }
+
+        retval.push(String::from(line));
+    }
+
+    Ok(retval)
+}
+
+pub fn run_containers(ctx: &ExecutionContext) -> Result<()> {
+    // Prefer podman, fall back to docker if not present
+    let crt = match require("podman") {
+        Ok(path) => path,
+        Err(_) => require("docker")?,
+    };
+    debug!("Using container runtime '{}'", crt.display());
+
+    print_separator("Containers");
+    let mut success = true;
+    let containers = list_containers(&crt)?;
+    debug!("Containers to inspect: {:?}", containers);
+
+    for container in containers.iter() {
+        let args = vec!["pull", &container[..]];
+
+        debug!("Pulling container '{}'", container);
+        if let Err(e) = ctx.run_type().execute(&crt).args(&args).check_run() {
+            // FIXME: Should this print a warning to stderr?
+            debug!("Pulling container '{}' failed: {}", container, e);
+            success = false;
+        }
+    }
+
+    if ctx.config().cleanup() {
+        // Remove dangling images
+        debug!("Removing dangling images");
+        if let Err(e) = ctx.run_type().execute(&crt).args(&["image", "prune", "-f"]).check_run() {
+            debug!("Removing dangling images failed: {}", e);
+            success = false;
+        }
+    }
+
+    if success {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(error::StepFailed))
+    }
+}

--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -35,6 +35,12 @@ fn list_containers(crt: &Path) -> Result<Vec<String>> {
             continue;
         }
 
+        if line.contains("<none>") {
+            // Bogus/dangling container or intermediate layer
+            debug!("Skipping bogus container '{}'", line);
+            continue;
+        }
+
         debug!("Using container '{}'", line);
         retval.push(String::from(line));
     }

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -1,3 +1,4 @@
+pub mod containers;
 pub mod emacs;
 pub mod generic;
 pub mod git;


### PR DESCRIPTION
This PR implements automatic updates for all available ~~podman~~podman/docker containers in the user installation (not roots containers). 
I'm aware of the discussion in #214, so I made the code respect the tags that the containers were initially pulled with to ensure that no semver-breaking changes are performed when a specific tag was checked out initially (Like rust does with Cargo.toml).

The code is still very rough in a lot of places, but I wanted to put it up for discussion before finishing it entirely. If your opinion from #214 still holds, feel free to close the issue immediately.


## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
