### PR TITLE
Support for updating kakoune plugins with kak-plug

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,7 @@ pub enum Step {
     GnomeShellExtensions,
     HomeManager,
     Jetpack,
+    Kakoune,
     Krew,
     Macports,
     Mas,

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,6 +308,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Vim, "vim", || vim::upgrade_vim(&base_dirs, &ctx))?;
     runner.execute(Step::Vim, "Neovim", || vim::upgrade_neovim(&base_dirs, &ctx))?;
     runner.execute(Step::Vim, "voom", || vim::run_voom(&base_dirs, run_type))?;
+    runner.execute(Step::Kakoune, "Kakoune", || kakoune::upgrade_kak_plug(&ctx))?;
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&ctx))?;
     runner.execute(Step::Pnpm, "pnpm", || node::pnpm_global_update(&ctx))?;
     runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;

--- a/src/steps/kakoune.rs
+++ b/src/steps/kakoune.rs
@@ -1,0 +1,31 @@
+use crate::error::TopgradeError;
+use crate::terminal::print_separator;
+use crate::utils::require;
+use anyhow::Result;
+
+use crate::execution_context::ExecutionContext;
+use crate::executor::ExecutorOutput;
+
+const UPGRADE_KAK: &str = include_str!("upgrade.kak");
+
+pub fn upgrade_kak_plug(ctx: &ExecutionContext) -> Result<()> {
+    let kak = require("kak")?;
+
+    print_separator("Kakoune");
+
+    let mut command = ctx.run_type().execute(&kak);
+    command.args(&["-ui", "dummy", "-e", UPGRADE_KAK]);
+
+    let output = command.output()?;
+
+    if let ExecutorOutput::Wet(output) = output {
+        let status = output.status;
+        if !status.success() {
+            return Err(TopgradeError::ProcessFailed(status).into());
+        } else {
+            println!("Plugins upgraded")
+        }
+    }
+
+    Ok(())
+}

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -1,6 +1,7 @@
 pub mod emacs;
 pub mod generic;
 pub mod git;
+pub mod kakoune;
 pub mod node;
 pub mod os;
 pub mod powershell;

--- a/src/steps/upgrade.kak
+++ b/src/steps/upgrade.kak
@@ -1,0 +1,6 @@
+try %{
+    set global plug_block_ui true;
+    plug-update;
+}
+
+quit 0;


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

I based this off of the vim plugin updater. unfortunately kak-plug does not seem to have a easy way of outputting it's progress and result. I do believe it's possible, but am unsure if such hacks would be welcome.