### PR TITLE
vim: Support updating dein

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -23,6 +23,11 @@ if exists(":PackerUpdate")
     PackerSync
 endif
 
+if exists("*dein#update()")
+    echo "dein#update()"
+    call dein#update()
+endif
+
 if exists(":DeinUpdate")
     echo "DeinUpdate"
     DeinUpdate


### PR DESCRIPTION
`dein` is a plugin manager for vim, which was supported for a while in
an earlier version of topgrade. This patch reintroduces support for
upgrading "plain" `dein`, rather that the `dein` UI which is invoked by
`DeinUpdate` in vim.

The commit that initially introduced `dein` support as implemented here was 57d3893a2b960e6c4fc8460f6bf4c3f30f546e20, but it got removed from topgrade in 5fb9b4177110d9e4890ab5eeca3f335d311b1b29. I didn't find any reason for that, did it happend on purpose?

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
