### PR TITLE
Add zgenom zsh plugin manager

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,7 @@ fn run() -> Result<()> {
         runner.execute(Step::Shell, "zr", || zsh::run_zr(&base_dirs, run_type))?;
         runner.execute(Step::Shell, "antibody", || zsh::run_antibody(run_type))?;
         runner.execute(Step::Shell, "antigen", || zsh::run_antigen(&base_dirs, run_type))?;
+        runner.execute(Step::Shell, "zgenom", || zsh::run_zgenom(&base_dirs, run_type))?;
         runner.execute(Step::Shell, "zplug", || zsh::run_zplug(&base_dirs, run_type))?;
         runner.execute(Step::Shell, "zinit", || zsh::run_zinit(&base_dirs, run_type))?;
         runner.execute(Step::Shell, "zim", || zsh::run_zim(&base_dirs, run_type))?;

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -51,6 +51,20 @@ pub fn run_antigen(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()
 }
 
+pub fn run_zgenom(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
+    let zsh = require("zsh")?;
+    let zshrc = zshrc(base_dirs).require()?;
+    env::var("ZGEN_SOURCE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| base_dirs.home_dir().join(".zgenom"))
+        .require()?;
+
+    print_separator("zgenom");
+
+    let cmd = format!("source {} && zgenom selfupdate && zgenom update", zshrc.display());
+    run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()
+}
+
 pub fn run_zplug(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let zsh = require("zsh")?;
     zshrc(base_dirs).require()?;
@@ -69,7 +83,7 @@ pub fn run_zinit(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc(base_dirs).require()?;
 
-    env::var("ZPFX")
+    env::var("ZINIT_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| base_dirs.home_dir().join(".zinit"))
         .require()?;


### PR DESCRIPTION
 - add the required functionality for zgenom
 - fix the env::var for zinit - it should be ZINIT_HOME, not ZBXF, as
   this is also set in zgenom, but makes topgrade fail when zinit is not
   installed

## Standards checklist:

- [x ] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`) - with some warnings that have nothin to do with my code
- [x ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
