### PR TITLE
Add support for upgrading GitHub CLI Extensions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,7 @@ pub enum Step {
     Fossil,
     Gcloud,
     Gem,
+    GithubCliExtensions,
     GitRepos,
     Go,
     Haxelib,

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Micro, "micro", || generic::run_micro(run_type))?;
     runner.execute(Step::Raco, "raco", || generic::run_raco_update(run_type))?;
     runner.execute(Step::Spicetify, "spicetify", || generic::spicetify_upgrade(&ctx))?;
+    runner.execute(Step::GithubCliExtensions, "Github CLI Extensions", || {
+        generic::run_ghcli_extensions_upgrade(&ctx)
+    })?;
 
     #[cfg(target_os = "linux")]
     {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -475,3 +475,13 @@ pub fn spicetify_upgrade(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Spicetify");
     ctx.run_type().execute(&spicetify).arg("upgrade").check_run()
 }
+
+pub fn run_ghcli_extensions_upgrade(ctx: &ExecutionContext) -> Result<()> {
+    let gh = utils::require("gh")?;
+
+    print_separator("GitHub CLI Extensions");
+    ctx.run_type()
+        .execute(&gh)
+        .args(&["extension", "upgrade", "--all"])
+        .check_run()
+}


### PR DESCRIPTION
Hi there!

This PR adds support for upgrading GitHub CLI extensions, which are custom commands for the [GitHub CLI](https://cli.github.com/) that anyone can create and use. Once installed locally, they can be upgraded from their respective upstream repos.
See https://docs.github.com/en/github-cli/github-cli/using-github-cli-extensions

This fixes #868 

Since this is my very first PR to this repo, please do let me know if things should be done differently.

Thanks.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

