### PR TITLE
steps: vim: Show outputs, simplify error handling

### DIFF
--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -1,7 +1,7 @@
-use crate::error::{SkipStep, TopgradeError};
+use crate::error::SkipStep;
 use anyhow::Result;
 
-use crate::executor::{CommandExt, ExecutorOutput, RunType};
+use crate::executor::{CommandExt, RunType};
 use crate::terminal::print_separator;
 use crate::{
     execution_context::ExecutionContext,
@@ -10,10 +10,7 @@ use crate::{
 use directories::BaseDirs;
 use log::debug;
 use std::path::{Path, PathBuf};
-use std::{
-    io::{self, Write},
-    process::Command,
-};
+use std::{io::Write, process::Command};
 
 const UPGRADE_VIM: &str = include_str!("upgrade.vim");
 
@@ -57,24 +54,7 @@ fn upgrade(vim: &Path, vimrc: &Path, ctx: &ExecutionContext) -> Result<()> {
         command.env("TOPGRADE_FORCE_PLUGUPDATE", "true");
     }
 
-    let output = command.output()?;
-
-    if let ExecutorOutput::Wet(output) = output {
-        let status = output.status;
-
-        if !status.success() || ctx.config().verbose() {
-            io::stdout().write(&output.stdout).ok();
-            io::stderr().write(&output.stderr).ok();
-        }
-
-        if !status.success() {
-            return Err(TopgradeError::ProcessFailed(status).into());
-        } else {
-            println!("Plugins upgraded")
-        }
-    }
-
-    Ok(())
+    command.check_run()
 }
 
 pub fn upgrade_vim(base_dirs: &BaseDirs, ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
Print stdout and stderr directly to the invoking terminal, rather than
collecting them and only printing them when the update failed.
Simplifies error handling by having the executor check for the command
exit status and automatically handling dry runs.

*Background*: I use `dein` as plugin manager for vim and had setup a custom update command for that in my topgrade config. I forgot to remove it after #857 was merged, so it stuck around. Recently I discovered that `vim-airline` [had a rewrite in its git-history](https://github.com/vim-airline/vim-airline/issues/2515), causing the update to fail but without `dein` returning an error exit status (i.e. it still returned 0). Thus the `vim` upgrade step would report "Plugins updated", whereas in the custom commands output I could see that it failed to upgrade one plugin. Since the other steps (at least the ones I use) also don't work silently (i.e. without showing me stdout/stderr), I decided to update the `vim` step to behave the same.


## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
