### PR TITLE
Use `docker image ls` instead of `docker images` to list images

### DIFF
--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -19,11 +19,11 @@ const NONEXISTENT_REPO: &str = "repository does not exist";
 /// "REGISTRY/[PATH/]CONTAINER_NAME:TAG"
 fn list_containers(crt: &Path) -> Result<Vec<String>> {
     debug!(
-        "Querying '{} images --format \"{{{{.Repository}}}}:{{{{.Tag}}}}\"' for containers",
+        "Querying '{} image ls --format \"{{{{.Repository}}}}:{{{{.Tag}}}}\"' for containers",
         crt.display()
     );
     let output = Command::new(crt)
-        .args(&["images", "--format", "{{.Repository}}:{{.Tag}}"])
+        .args(&["image", "ls", "--format", "{{.Repository}}:{{.Tag}}"])
         .output()?;
     let output_str = String::from_utf8(output.stdout)?;
 


### PR DESCRIPTION
Use the same format for all `docker image` commands

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
