### PR TITLE
Fix: remove doas option (--preserve-env=DIFFPROG)

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -549,7 +549,6 @@ pub fn run_config_update(ctx: &ExecutionContext) -> Result<()> {
         print_separator("Configuration update");
         ctx.run_type()
             .execute(sudo)
-            .arg("--preserve-env=DIFFPROG")
             .arg(pacdiff)
             .check_run()?;
     }


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles (`cargo build`)
- [X] The code passes rustfmt (`cargo fmt`)
- [X] The code passes clippy (`cargo clippy`)
- [X] The code passes tests (`cargo test`)
- [X] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
