### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Micro, "micro", || generic::run_micro(run_type))?;
     runner.execute(Step::Raco, "raco", || generic::run_raco_update(run_type))?;
     runner.execute(Step::Spicetify, "spicetify", || generic::spicetify_upgrade(&ctx))?;
-    runner.execute(Step::GithubCliExtensions, "Github CLI Extensions", || {
+    runner.execute(Step::GithubCliExtensions, "GitHub CLI Extensions", || {
         generic::run_ghcli_extensions_upgrade(&ctx)
     })?;
 


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
