### PR TITLE
Always display quit

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -228,13 +228,9 @@ impl Terminal {
         self.term
             .write_fmt(format_args!(
                 "\n{}",
-                style(format!(
-                    "{}Retry? (y)es/(N)o/(s)hell{}",
-                    self.prefix,
-                    if interrupted { "/(q)uit" } else { "" }
-                ))
-                .yellow()
-                .bold()
+                style(format!("{}Retry? (y)es/(N)o/(s)hell/(q)uit", self.prefix))
+                    .yellow()
+                    .bold()
             ))
             .ok();
 


### PR DESCRIPTION
you can always press q to quit so it should also always be displayed

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
