### PR TITLE
Fix building for Android, enable `tlmgr` updates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -280,7 +280,7 @@ fn run() -> Result<()> {
         runner.execute(Step::Tmux, "tmux", || tmux::run_tpm(&base_dirs, run_type))?;
         runner.execute(Step::Tldr, "TLDR", || unix::run_tldr(run_type))?;
         runner.execute(Step::Pearl, "pearl", || unix::run_pearl(run_type))?;
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "android")))]
         runner.execute(Step::GnomeShellExtensions, "Gnome Shell Extensions", || {
             unix::upgrade_gnome_extensions(&ctx)
         })?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -285,9 +285,9 @@ pub fn run_stack_update(run_type: RunType) -> Result<()> {
 
 pub fn run_tlmgr_update(ctx: &ExecutionContext) -> Result<()> {
     cfg_if::cfg_if! {
-        if #[cfg(target_os = "linux")] {
+        if #[cfg(any(target_os = "linux", target_os = "android"))] {
             if !ctx.config().enable_tlmgr_linux() {
-                return Err(SkipStep(String::from("tlmgr must be explicity enabled in the configuration to run in Linux")).into());
+                return Err(SkipStep(String::from("tlmgr must be explicity enabled in the configuration to run in Android/Linux")).into());
             }
         }
     }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -135,7 +135,7 @@ pub fn run_fish_plug(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(&fish).args(&["-c", "plug update"]).check_run()
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "android", target_os = "macos")))]
 pub fn upgrade_gnome_extensions(ctx: &ExecutionContext) -> Result<()> {
     let gdbus = require("gdbus")?;
     require_option(


### PR DESCRIPTION
- fix(os/unix): cannot find `SkipStep` while building for android
- feat: enable `tlmgr` updates for android

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #895
