### PR TITLE
Fix: correct option name

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -46,7 +46,7 @@
 #]
 
 # Don't pull the predefined git repos
-#predefined_repos = false
+#pull_predefined = false
 
 # Arguments to pass Git when pulling Repositories
 #arguments = "--rebase --autostash"


### PR DESCRIPTION
The option name is now `pull_predefined`. This commit fixed the template config with the new option name

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles (`cargo build`)
- [X] The code passes rustfmt (`cargo fmt`)
- [X] The code passes clippy (`cargo clippy`)
- [X] The code passes tests (`cargo test`)
- [X] *Optional:* I have tested the code myself
    - [X] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
