### PR TITLE
Fix docs of arch_package_manager fn

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -692,7 +692,7 @@ impl Config {
             .unwrap_or(true)
     }
 
-    /// Extra yay arguments
+    /// Get the package manager of an Arch Linux system
     pub fn arch_package_manager(&self) -> ArchPackageManager {
         self.config_file
             .linux


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
