### PR TITLE
pip should be executed via the regular python executable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'topgrade'",
+            "name": "Topgrade",
             "console": "integratedTerminal",
             "cargo": {
                 "args": [
@@ -20,27 +20,19 @@
                     "kind": "bin"
                 }
             },
-            "args": [],
+            "args": [
+                "--only",
+                "${input:step}",
+                "-v"
+            ],
             "cwd": "${workspaceFolder}"
         },
+    ],
+    "inputs": [
         {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug unit tests in executable 'topgrade'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--bin=topgrade",
-                    "--package=topgrade"
-                ],
-                "filter": {
-                    "name": "topgrade",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
+            "type": "promptString",
+            "id": "step",
+            "description": "step nname",
         }
     ]
 }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -263,7 +263,12 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_pip3_update(run_type: RunType) -> Result<()> {
-    let pip3 = utils::require("pip3")?;
+    let python3 = utils::require("python3")?;
+    Command::new(&python3)
+        .args(&["-m", "pip"])
+        .check_output()
+        .map_err(|_| SkipStep("pip does not exists".to_string()))?;
+
     print_separator("pip3");
     if std::env::var("VIRTUAL_ENV").is_ok() {
         print_warning("This step is will be skipped when running inside a virtual environment");
@@ -271,8 +276,8 @@ pub fn run_pip3_update(run_type: RunType) -> Result<()> {
     }
 
     run_type
-        .execute(&pip3)
-        .args(&["install", "--upgrade", "--user", "pip"])
+        .execute(&python3)
+        .args(&["-m", "pip", "install", "--upgrade", "--user", "pip"])
         .check_run()
 }
 


### PR DESCRIPTION
Fixes #910

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
