### PR TITLE
npm/cli 8.11.0 deprecated -g flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,7 @@ dependencies = [
  "regex",
  "rust-ini",
  "self_update",
+ "semver",
  "serde",
  "shellexpand",
  "strum 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1.5.0", features = ["process", "rt-multi-thread"] }
 futures = "0.3.14"
 regex = "1.5.3"
 sys-info = "0.9"
+semver = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 notify-rust = "4.5.0"

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -56,7 +56,7 @@ impl NPM {
     fn upgrade(&self, run_type: RunType, use_sudo: bool) -> Result<()> {
         print_separator("Node Package Manager");
         let version = self.version()?;
-        let args = if version < Version::new(8, 11, 0) && self.pnpm.is_none() {
+        let args = if version < Version::new(8, 11, 0) || self.pnpm.is_some() {
             ["update", "-g"]
         } else {
             ["update", "--location=global"]

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -56,7 +56,7 @@ impl NPM {
     fn upgrade(&self, run_type: RunType, use_sudo: bool) -> Result<()> {
         print_separator("Node Package Manager");
         let version = self.version()?;
-        let args = if version < Version::new(8, 11, 0) {
+        let args = if version < Version::new(8, 11, 0) && self.pnpm.is_none() {
             ["update", "-g"]
         } else {
             ["update", "--location=global"]


### PR DESCRIPTION
As of https://github.com/npm/cli/releases/tag/v8.11.0 npm deprecated `-g` syntax replaced with `--location=global`

```
―― 16:27:28 - Node Package Manager ―――――――――――――――――――――――――――――――――――――――――――――
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
```
## Standards checklist:

- [ ] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed
