### PR TITLE
Add Pamac support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -66,13 +66,14 @@
 #greedy_cask = true
 
 [linux]
-# Arch Package Manager to use. Allowed values: autodetect, trizen, paru, yay, pikaur, pacman.
+# Arch Package Manager to use. Allowed values: autodetect, trizen, paru, yay, pikaur, pacman, pamac.
 #arch_package_manager = "pacman"
 # Arguments to pass yay (or paru) when updating packages
 #yay_arguments = "--nodevel"
 #show_arch_news = true
 #trizen_arguments = "--devel"
 #pikaur_arguments = ""
+#pamac_arguments = "--no-devel"
 #enable_tlmgr = true
 #emerge_sync_flags = "-q"
 #emerge_update_flags = "-uDNa --with-bdeps=y world"

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,7 @@ pub enum ArchPackageManager {
     Yay,
     Pacman,
     Pikaur,
+    Pamac,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -211,6 +212,7 @@ pub struct Linux {
     show_arch_news: Option<bool>,
     trizen_arguments: Option<String>,
     pikaur_arguments: Option<String>,
+    pamac_arguments: Option<String>,
     dnf_arguments: Option<String>,
     apt_arguments: Option<String>,
     enable_tlmgr: Option<bool>,
@@ -692,6 +694,15 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|s| s.pikaur_arguments.as_deref())
+            .unwrap_or("")
+    }
+
+    /// Extra Pamac arguments
+    pub fn pamac_arguments(&self) -> &str {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|s| s.pamac_arguments.as_deref())
             .unwrap_or("")
     }
 

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -235,12 +235,14 @@ pub fn get_arch_package_manager(ctx: &ExecutionContext) -> Option<Box<dyn ArchPa
             .or_else(|| YayParu::get("yay", &pacman).map(box_package_manager))
             .or_else(|| Trizen::get().map(box_package_manager))
             .or_else(|| Pikaur::get().map(box_package_manager))
+            .or_else(|| Pamac::get().map(box_package_manager))
             .or_else(|| Pacman::get(ctx).map(box_package_manager)),
         config::ArchPackageManager::Trizen => Trizen::get().map(box_package_manager),
         config::ArchPackageManager::Paru => YayParu::get("paru", &pacman).map(box_package_manager),
         config::ArchPackageManager::Yay => YayParu::get("yay", &pacman).map(box_package_manager),
         config::ArchPackageManager::Pacman => Pacman::get(ctx).map(box_package_manager),
         config::ArchPackageManager::Pikaur => Pikaur::get().map(box_package_manager),
+        config::ArchPackageManager::Pamac => Pamac::get().map(box_package_manager),
     }
 }
 

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -216,7 +216,14 @@ impl ArchPackageManager for Pamac {
 
         command.check_run()?;
 
-        // TODO: cleanup
+        if ctx.config().cleanup() {
+            let mut command = ctx.run_type().execute(&self.executable);
+            command.arg("clean");
+            if ctx.config().yes(Step::System) {
+                command.arg("--no-confirm");
+            }
+            command.check_run()?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

I have not tested the patch yet but I will at first opportunity.

Additionally, I have no implemented cleanup yet. I am still researching how Pamac does this through the CLI.