### PR TITLE
Ensure `selfupdate` is enabled for SDKMAN!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,15 +41,13 @@ notify-rust = "4.5.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.24.1"
+rust-ini = "0.18.0"
 self_update_crate = { version = "0.30.0", default-features = false, optional = true, package = "self_update", features = ["archive-tar", "compression-flate2", "rustls"] }
 
 [target.'cfg(windows)'.dependencies]
 self_update_crate = { version = "0.30.0", default-features = false, optional = true, package = "self_update", features = ["archive-zip", "compression-zip-deflate", "rustls"] }
 winapi = "0.3.9"
 parselnk = "0.1.0"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-rust-ini = "0.18.0"
 
 [profile.release]
 lto = true

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -349,15 +349,13 @@ pub fn run_sdkman(base_dirs: &BaseDirs, cleanup: bool, run_type: RunType) -> Res
         .unwrap_or_else(|_| base_dirs.home_dir().join(".sdkman"))
         .join("etc")
         .join("config")
-        .require()
-        .map(|p| format!("{}", &p.display()))?;
+        .require()?;
 
     let sdkman_config = Ini::load_from_file(sdkman_config_path)?;
-    let selfupdate_enabled: String = sdkman_config
+    let selfupdate_enabled = sdkman_config
         .general_section()
         .get("sdkman_selfupdate_feature")
-        .unwrap_or("false")
-        .into();
+        .unwrap_or("false");
 
     if selfupdate_enabled == "true" {
         let cmd_selfupdate = format!("source {} && sdk selfupdate", &sdkman_init_path);


### PR DESCRIPTION
This subcommand is unavailable when the `sdkman_selfupdate_feature`
option is disabled, as is the case when SDKMAN! is installed via
Homebrew.

https://github.com/sdkman/sdkman-cli/pull/1042

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
