### PR TITLE
fix: skip nix on darwin

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -274,6 +274,16 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(..) = require("darwin-rebuild") {
+            return Err(SkipStep(String::from(
+                "Nix-darwin on macOS must be upgraded via darwin-rebuild switch",
+            ))
+            .into());
+        }
+    }
+
     let run_type = ctx.run_type();
 
     if should_self_upgrade {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

Fix https://github.com/r-darwish/topgrade/issues/965
