### PR TITLE
Clean up OPAM directories if requested when running `topgrade`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Flutter, "Flutter", || generic::run_flutter_upgrade(run_type))?;
     runner.execute(Step::Go, "Go", || generic::run_go(run_type))?;
     runner.execute(Step::Emacs, "Emacs", || emacs.upgrade(&ctx))?;
-    runner.execute(Step::Opam, "opam", || generic::run_opam_update(run_type))?;
+    runner.execute(Step::Opam, "opam", || generic::run_opam_update(&ctx))?;
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(run_type))?;
     runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(run_type))?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -220,13 +220,19 @@ pub fn run_rtcl(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(&rupdate).check_run()
 }
 
-pub fn run_opam_update(run_type: RunType) -> Result<()> {
+pub fn run_opam_update(ctx: &ExecutionContext) -> Result<()> {
     let opam = utils::require("opam")?;
 
     print_separator("OCaml Package Manager");
 
-    run_type.execute(&opam).arg("update").check_run()?;
-    run_type.execute(&opam).arg("upgrade").check_run()
+    ctx.run_type().execute(&opam).arg("update").check_run()?;
+    ctx.run_type().execute(&opam).arg("upgrade").check_run()?;
+
+    if ctx.config().cleanup() {
+        ctx.run_type().execute(&opam).arg("clean").check_run()?;
+    }
+
+    Ok(())
 }
 
 pub fn run_vcpkg_update(run_type: RunType) -> Result<()> {


### PR DESCRIPTION
OPAM has a built-in `clean` command that automatically
removes download caches, logs, and cleans the current
OPAM switch. We should call `opam clean` when the
cleanup flag is set.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
