### PR TITLE
Fix neovim upgrade

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -18,11 +18,6 @@ if exists(":PlugUpgrade")
     endif
 endif
 
-if exists(":PackerUpdate")
-    echo "Packer"
-    PackerSync
-endif
-
 if exists("*dein#update()")
     echo "dein#update()"
     call dein#update()
@@ -43,4 +38,10 @@ if exists(":CocUpdateSync")
     CocUpdateSync
 endif
 
-quitall
+if exists(':PackerSync')
+  echo "Packer"
+  autocmd User PackerComplete quitall
+  PackerSync
+else
+  quitall
+endif


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Fix neovim upgrade (command line arguments are different from the vim's one) and fix the upgrade script when using Packer.

https://asciinema.org/a/vxfsGPHxp0BteRssN4OrpuvvR
