### PR TITLE
steps/linux/flatpak: Respect `-y` flag

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -491,44 +491,50 @@ pub fn flatpak_update(ctx: &ExecutionContext) -> Result<()> {
     let flatpak = require("flatpak")?;
     let sudo = require_option(ctx.sudo().as_ref(), String::from("sudo is not installed"))?;
     let cleanup = ctx.config().cleanup();
+    let yes = ctx.config().yes(Step::Flatpak);
     let run_type = ctx.run_type();
     print_separator("Flatpak User Packages");
 
-    run_type
-        .execute(&flatpak)
-        .args(&["update", "--user", "-y"])
-        .check_run()?;
+    let mut update_args = vec!["update", "--user"];
+    if yes {
+        update_args.push("-y");
+    }
+    run_type.execute(&flatpak).args(&update_args).check_run()?;
+
     if cleanup {
-        run_type
-            .execute(&flatpak)
-            .args(&["uninstall", "--user", "--unused"])
-            .check_run()?;
+        let mut cleanup_args = vec!["uninstall", "--user", "--unused"];
+        if yes {
+            cleanup_args.push("-y");
+        }
+        run_type.execute(&flatpak).args(&cleanup_args).check_run()?;
     }
 
     print_separator("Flatpak System Packages");
     if ctx.config().flatpak_use_sudo() || std::env::var("SSH_CLIENT").is_ok() {
-        run_type
-            .execute(&sudo)
-            .arg(&flatpak)
-            .args(&["update", "--system", "-y"])
-            .check_run()?;
+        let mut update_args = vec!["update", "--system"];
+        if yes {
+            update_args.push("-y");
+        }
+        run_type.execute(&sudo).arg(&flatpak).args(&update_args).check_run()?;
         if cleanup {
-            run_type
-                .execute(sudo)
-                .arg(flatpak)
-                .args(&["uninstall", "--system", "--unused"])
-                .check_run()?;
+            let mut cleanup_args = vec!["uninstall", "--system", "--unused"];
+            if yes {
+                cleanup_args.push("-y");
+            }
+            run_type.execute(sudo).arg(flatpak).args(&cleanup_args).check_run()?;
         }
     } else {
-        run_type
-            .execute(&flatpak)
-            .args(&["update", "--system", "-y"])
-            .check_run()?;
+        let mut update_args = vec!["update", "--system"];
+        if yes {
+            update_args.push("-y");
+        }
+        run_type.execute(&flatpak).args(&update_args).check_run()?;
         if cleanup {
-            run_type
-                .execute(flatpak)
-                .args(&["uninstall", "--system", "--unused"])
-                .check_run()?;
+            let mut cleanup_args = vec!["uninstall", "--system", "--unused"];
+            if yes {
+                cleanup_args.push("-y");
+            }
+            run_type.execute(flatpak).args(&cleanup_args).check_run()?;
         }
     }
 


### PR DESCRIPTION
when deciding whether the `-y` argument should be added to an operation.
Previously the `-y` was implicitly assumed for regular updates but was
ignored for the cleanup steps.

Now, it is added as defined in the topgrade runtime configuration.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
