### PR TITLE
Add FreeBSD port/package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To remedy this, _topgrade_ detects which tools you use and runs the appropriate 
 - Arch Linux: [AUR](https://aur.archlinux.org/packages/topgrade/) package.
 - NixOS: _topgrade_ package in `nixpkgs`.
 - macOS: [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/install.php).
+- FreeBSD: [Ports](https://www.freshports.org/sysutils/topgrade/).
 
 Other systems users can either use `cargo install` or use the compiled binaries from the release page.
 The compiled binaries contain a self-upgrading feature.


### PR DESCRIPTION
Add FreeBSD port url where could be found instructions to build topgrade from source and packages available.

Nuno Teixeira
FreeBSD Ports Committer

## Standards checklist:

- [x] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
