### PR TITLE
Fix typo in config.example.toml comments (to -> or)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -87,7 +87,7 @@
 
 # Causes Topgrade to rename itself during the run to allow package managers
 # to upgrade it. Use this only if you installed Topgrade by using a package
-# manager such as Scoop to Cargo
+# manager such as Scoop or Cargo
 #self_rename = true
 
 [npm]


### PR DESCRIPTION
## Standards checklist:

I have not tested this change in any way.

- [x] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
