### PR TITLE
feat: add support for bun

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,7 @@ pub enum Step {
     Atom,
     BrewCask,
     BrewFormula,
+    Bun,
     Bin,
     Cargo,
     Chezmoi,

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,7 @@ fn run() -> Result<()> {
         runner.execute(Step::HomeManager, "home-manager", || unix::run_home_manager(run_type))?;
         runner.execute(Step::Asdf, "asdf", || unix::run_asdf(run_type))?;
         runner.execute(Step::Pkgin, "pkgin", || unix::run_pkgin(&ctx))?;
+        runner.execute(Step::Bun, "bun", || unix::run_bun(&ctx))?;
     }
 
     #[cfg(target_os = "dragonfly")]

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -391,6 +391,14 @@ pub fn run_sdkman(base_dirs: &BaseDirs, cleanup: bool, run_type: RunType) -> Res
     Ok(())
 }
 
+pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
+    let bun = require("bun")?;
+
+    print_separator("Bun");
+
+    ctx.run_type().execute(&bun).arg("upgrade").check_run()
+}
+
 pub fn reboot() {
     print!("Rebooting...");
     Command::new("sudo").arg("reboot").spawn().unwrap().wait().unwrap();


### PR DESCRIPTION
Hello ! :wave: 

I took the liberty to add support for [bun](https://github.com/oven-sh/bun), a recent and promising JavaScript tool and runtime.

It features self update, so I was able to derive existing work in the repository.

One thing I was not sure about is in which `cfg` part in `config.rs` I should add my step since Bun is only available for Linux and macOS at this time. If I put it in the wrong part, please indicate me, I will move i tto the right place.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
