### PR TITLE
[#993] Homebrew autoremove option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -64,6 +64,7 @@
 
 [brew]
 #greedy_cask = true
+#autoremove = true
 
 [linux]
 # Arch Package Manager to use. Allowed values: autodetect, trizen, paru, yay, pikaur, pacman, pamac.

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,6 +191,7 @@ pub struct Flatpak {
 #[serde(deny_unknown_fields)]
 pub struct Brew {
     greedy_cask: Option<bool>,
+    autoremove: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
@@ -653,6 +654,15 @@ impl Config {
             .brew
             .as_ref()
             .and_then(|c| c.greedy_cask)
+            .unwrap_or(false)
+    }
+
+    /// Whether Brew should autoremove
+    pub fn brew_autoremove(&self) -> bool {
+        self.config_file
+            .brew
+            .as_ref()
+            .and_then(|c| c.autoremove)
             .unwrap_or(false)
     }
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -210,6 +210,10 @@ pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<
         variant.execute(run_type).arg("cleanup").check_run()?;
     }
 
+    if ctx.config().brew_autoremove() {
+        variant.execute(run_type).arg("autoremove").check_run()?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Small little feature that adds the option to have homebrew do a `brew autoremove` after brew formula installs

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
