### PR TITLE
add pacdef support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,7 @@ pub enum Step {
     Nix,
     Node,
     Opam,
+    Pacdef,
     Pacstall,
     Pearl,
     Pipx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,7 @@ fn run() -> Result<()> {
         runner.execute(Step::Flatpak, "Flatpak", || linux::flatpak_update(&ctx))?;
         runner.execute(Step::Snap, "snap", || linux::run_snap(sudo.as_ref(), run_type))?;
         runner.execute(Step::Pacstall, "pacstall", || linux::run_pacstall(&ctx))?;
+        runner.execute(Step::Pacdef, "pacdef", || linux::run_pacdef(&ctx))?;
     }
 
     if let Some(commands) = config.commands() {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -348,6 +348,17 @@ fn upgrade_solus(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
+pub fn run_pacdef(ctx: &ExecutionContext) -> Result<()> {
+    let pacdef = require("pacdef")?;
+
+    print_separator("pacdef");
+
+    ctx.run_type().execute(&pacdef).arg("sync").check_run()?;
+
+    println!();
+    ctx.run_type().execute(&pacdef).arg("review").check_run()
+}
+
 pub fn run_pacstall(ctx: &ExecutionContext) -> Result<()> {
     let pacstall = require("pacstall")?;
 


### PR DESCRIPTION
This simple commit adds support for `pacdef`, which is a declarative package manager for Arch Linux.

https://github.com/steven-omaha/pacdef

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed